### PR TITLE
revert: undo direct commits to main

### DIFF
--- a/crates/router-hosts/src/server/db/event_store.rs
+++ b/crates/router-hosts/src/server/db/event_store.rs
@@ -161,7 +161,6 @@ impl EventStore {
         })?;
 
         // Single INSERT statement for all event types
-        // Use make_timestamp() to convert microseconds to TIMESTAMP
         db.conn()
             .execute(
                 r#"
@@ -169,7 +168,7 @@ impl EventStore {
                     event_id, aggregate_id, event_type, event_version,
                     ip_address, hostname, event_timestamp, metadata,
                     created_at, created_by, expected_version
-                ) VALUES (?, ?, ?, ?, ?, ?, make_timestamp(?), ?, make_timestamp(?), ?, ?)
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 "#,
                 [
                     &event_id.to_string() as &dyn duckdb::ToSql,
@@ -178,9 +177,9 @@ impl EventStore {
                     &new_version,
                     &ip_address_opt as &dyn duckdb::ToSql,
                     &hostname_opt as &dyn duckdb::ToSql,
-                    &event_timestamp.timestamp_micros(),
+                    &event_timestamp.to_rfc3339(),
                     &event_data_json as &dyn duckdb::ToSql,
-                    &now.timestamp_micros(),
+                    &now.to_rfc3339(),
                     &created_by.as_deref().unwrap_or("system"),
                     &expected_version,
                 ],

--- a/crates/router-hosts/src/server/db/schema.rs
+++ b/crates/router-hosts/src/server/db/schema.rs
@@ -44,21 +44,6 @@ pub type DatabaseResult<T> = Result<T, DatabaseError>;
 /// - Read models are projections built from events using DuckDB views
 /// - No soft deletes - event log captures complete history
 /// - Time travel queries supported via event replay
-///
-/// # Thread Safety
-///
-/// A single `Database` instance wraps a single DuckDB connection, which is
-/// NOT thread-safe. For concurrent access from multiple threads:
-///
-/// 1. Use [`try_clone()`](Self::try_clone) to create additional connections
-///    that share the same underlying database
-/// 2. Each thread should have its own cloned connection
-/// 3. DuckDB handles concurrency internally when using cloned connections
-///
-/// ```ignore
-/// let db = Database::new(path)?;
-/// let db_clone = db.try_clone()?;  // For another thread
-/// ```
 pub struct Database {
     conn: Connection,
 }
@@ -177,21 +162,6 @@ impl Database {
                 DatabaseError::SchemaInitFailed(format!("Failed to create temporal index: {}", e))
             })?;
 
-        // Composite index for efficient current hosts view queries
-        // The view filters by event_type and orders by hostname
-        // Note: Can't index INET type directly, but event_type + hostname helps
-        self.conn
-            .execute(
-                "CREATE INDEX IF NOT EXISTS idx_events_type_hostname ON host_events(event_type, hostname)",
-                [],
-            )
-            .map_err(|e| {
-                DatabaseError::SchemaInitFailed(format!(
-                    "Failed to create composite index: {}",
-                    e
-                ))
-            })?;
-
         // Read model: Current active hosts projection
         // This materialized view is built from events and optimized for queries
         // Uses first-class typed columns plus JSON metadata
@@ -285,66 +255,6 @@ impl Database {
     pub(crate) fn conn(&self) -> &Connection {
         &self.conn
     }
-
-    /// Clone this database connection for use in another thread
-    ///
-    /// Creates a new connection that shares the same underlying database.
-    /// Both connections can operate concurrently - DuckDB handles the
-    /// synchronization internally.
-    ///
-    /// # Example
-    ///
-    /// ```ignore
-    /// let db = Database::new(path)?;
-    /// let db_clone = db.try_clone()?;
-    ///
-    /// std::thread::spawn(move || {
-    ///     // Use db_clone in this thread
-    /// });
-    /// ```
-    pub fn try_clone(&self) -> DatabaseResult<Self> {
-        let conn = self.conn.try_clone().map_err(|e| {
-            DatabaseError::ConnectionFailed(format!("Failed to clone connection: {}", e))
-        })?;
-        Ok(Self { conn })
-    }
-
-    /// Execute a function within a database transaction
-    ///
-    /// The transaction is automatically committed if the function returns `Ok`,
-    /// or rolled back if it returns `Err` or panics.
-    ///
-    /// # Example
-    ///
-    /// ```ignore
-    /// db.transaction(|conn| {
-    ///     conn.execute("INSERT INTO ...", [])?;
-    ///     conn.execute("UPDATE ...", [])?;
-    ///     Ok(())
-    /// })?;
-    /// ```
-    pub fn transaction<T, F>(&mut self, f: F) -> DatabaseResult<T>
-    where
-        F: FnOnce(&Connection) -> DatabaseResult<T>,
-    {
-        self.conn.execute("BEGIN TRANSACTION", []).map_err(|e| {
-            DatabaseError::QueryFailed(format!("Failed to begin transaction: {}", e))
-        })?;
-
-        match f(&self.conn) {
-            Ok(result) => {
-                self.conn.execute("COMMIT", []).map_err(|e| {
-                    DatabaseError::QueryFailed(format!("Failed to commit transaction: {}", e))
-                })?;
-                Ok(result)
-            }
-            Err(e) => {
-                // Attempt rollback, but don't mask the original error
-                let _ = self.conn.execute("ROLLBACK", []);
-                Err(e)
-            }
-        }
-    }
 }
 
 #[cfg(test)]
@@ -419,91 +329,5 @@ mod tests {
 
         // JSON metadata column (tags, comments, previous values)
         assert!(cols.contains(&"metadata".to_string()));
-    }
-
-    #[test]
-    fn test_transaction_commit() {
-        let mut db = Database::in_memory().unwrap();
-
-        // Create a test table
-        db.conn()
-            .execute("CREATE TABLE test_tx (id INTEGER, value TEXT)", [])
-            .unwrap();
-
-        // Transaction that commits
-        let result = db.transaction(|conn| {
-            conn.execute("INSERT INTO test_tx VALUES (1, 'first')", [])
-                .map_err(|e| DatabaseError::QueryFailed(e.to_string()))?;
-            conn.execute("INSERT INTO test_tx VALUES (2, 'second')", [])
-                .map_err(|e| DatabaseError::QueryFailed(e.to_string()))?;
-            Ok(())
-        });
-
-        assert!(result.is_ok());
-
-        // Verify data was committed
-        let count: i32 = db
-            .conn()
-            .query_row("SELECT COUNT(*) FROM test_tx", [], |row| row.get(0))
-            .unwrap();
-        assert_eq!(count, 2);
-    }
-
-    #[test]
-    fn test_transaction_rollback() {
-        let mut db = Database::in_memory().unwrap();
-
-        // Create a test table
-        db.conn()
-            .execute("CREATE TABLE test_tx_rollback (id INTEGER, value TEXT)", [])
-            .unwrap();
-
-        // Insert initial data outside transaction
-        db.conn()
-            .execute("INSERT INTO test_tx_rollback VALUES (1, 'initial')", [])
-            .unwrap();
-
-        // Transaction that fails and rolls back
-        let result: DatabaseResult<()> = db.transaction(|conn| {
-            conn.execute(
-                "INSERT INTO test_tx_rollback VALUES (2, 'will rollback')",
-                [],
-            )
-            .map_err(|e| DatabaseError::QueryFailed(e.to_string()))?;
-            // Simulate an error
-            Err(DatabaseError::QueryFailed("Simulated error".to_string()))
-        });
-
-        assert!(result.is_err());
-
-        // Verify only initial data exists (transaction was rolled back)
-        let count: i32 = db
-            .conn()
-            .query_row("SELECT COUNT(*) FROM test_tx_rollback", [], |row| {
-                row.get(0)
-            })
-            .unwrap();
-        assert_eq!(count, 1);
-    }
-
-    #[test]
-    fn test_try_clone() {
-        let db = Database::in_memory().unwrap();
-
-        // Insert data using original connection
-        db.conn()
-            .execute("CREATE TABLE test_clone (id INTEGER)", [])
-            .unwrap();
-        db.conn()
-            .execute("INSERT INTO test_clone VALUES (42)", [])
-            .unwrap();
-
-        // Clone and verify both see the same data
-        let db_clone = db.try_clone().unwrap();
-        let value: i32 = db_clone
-            .conn()
-            .query_row("SELECT id FROM test_clone", [], |row| row.get(0))
-            .unwrap();
-        assert_eq!(value, 42);
     }
 }

--- a/proto/router_hosts/v1/hosts.proto
+++ b/proto/router_hosts/v1/hosts.proto
@@ -7,9 +7,8 @@ import "google/protobuf/timestamp.proto";
 // Host entry messages
 
 // Represents a single host entry in the /etc/hosts file
-// This is a projection built from the event-sourced data model
 message HostEntry {
-  // Unique identifier for this host entry (ULID format for lexicographic ordering)
+  // Unique identifier for this host entry (UUID format)
   string id = 1;
 
   // IP address (IPv4 or IPv6) for the host
@@ -30,9 +29,8 @@ message HostEntry {
   // Timestamp when this entry was last updated
   google.protobuf.Timestamp updated_at = 7;
 
-  // Event version for optimistic concurrency control
-  // Include this in update requests to prevent lost updates
-  int64 version = 8;
+  // Whether this entry is active (false = soft deleted, won't appear in /etc/hosts)
+  bool active = 8;
 }
 
 // Host management requests/responses
@@ -96,10 +94,6 @@ message UpdateHostRequest {
   // New tags array (replaces all existing tags). Empty array = clear all tags.
   // Not providing this field = keep existing tags unchanged.
   repeated string tags = 6;
-
-  // Expected version for optimistic concurrency control (optional)
-  // If provided and doesn't match current version, update fails with ABORTED status
-  optional int64 expected_version = 7;
 }
 
 // Response after updating a host entry
@@ -108,19 +102,13 @@ message UpdateHostResponse {
   HostEntry entry = 1;
 }
 
-// Request to delete a host entry (creates HostDeleted tombstone event)
+// Request to delete a host entry (soft delete by setting active=false)
 message DeleteHostRequest {
   // Optional edit session token. If provided, deletion is staged; if omitted, entry is deleted immediately
   optional string edit_token = 1;
 
   // ID of the host entry to delete
   string id = 2;
-
-  // Optional reason for deletion (stored in event log for audit)
-  optional string reason = 3;
-
-  // Expected version for optimistic concurrency control (optional)
-  optional int64 expected_version = 4;
 }
 
 // Response after deleting a host entry
@@ -344,7 +332,7 @@ service HostsService {
   // Update an existing host entry
   rpc UpdateHost(UpdateHostRequest) returns (UpdateHostResponse);
 
-  // Delete a host entry (creates HostDeleted tombstone event in event log)
+  // Delete a host entry (soft delete by setting active=false)
   rpc DeleteHost(DeleteHostRequest) returns (DeleteHostResponse);
 
   // List all host entries with optional filtering and pagination (server streaming)


### PR DESCRIPTION
## Summary

Reverting commits that were incorrectly pushed directly to main instead of going through a PR:
- `cd71e74` docs: align documentation and proto with event-sourced implementation
- `19b5b8f` fix(db): address code review issues from PR #3

These changes will be re-submitted via a proper feature branch and PR after this revert is merged.

## Why

Changes should go through PRs for review, not be pushed directly to main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)