### PR TITLE
docs: mark import conflict modes as complete

### DIFF
--- a/docs/plans/2025-12-01-v1-tasks.md
+++ b/docs/plans/2025-12-01-v1-tasks.md
@@ -1,7 +1,7 @@
 # router-hosts v1.0 Implementation Tasks
 
 **Date:** 2025-12-01
-**Last Updated:** 2025-12-07
+**Last Updated:** 2025-12-08
 **Status:** Active development - Client CLI complete, server features in progress
 **Related:** [v1.0 Design Document](2025-12-01-router-hosts-v1-design.md)
 
@@ -30,7 +30,6 @@
 |------|-------|-------------|
 | ULID versioning | #45 | Store ULIDs as versions (currently uses event_version) |
 | Version check on update | #46 | Server returns ABORTED on version mismatch |
-| Import conflict modes | #47 | Implement "replace" and "strict" (currently skip only) |
 
 #### Medium Priority
 | Task | Issue | Description |
@@ -81,4 +80,5 @@ Issues created from PR #36 code review:
 | ExportHosts RPC | 2025-12-04 | PR #22 - hosts/json/csv formats |
 | Integration tests | 2025-12-04 | PR #21 - gRPC integration tests |
 | ImportHosts RPC | 2025-12-05 | PR #33 - Bidirectional streaming |
+| Import conflict modes | 2025-12-05 | PR #33 - Skip/replace/strict modes |
 | Client CLI | 2025-12-06 | PR #36 - Complete CLI with all commands |


### PR DESCRIPTION
## Summary

Issue #47 was created based on an outdated task list, but the feature was already fully implemented in PR #33.

## Changes

- Remove "Import conflict modes" from High Priority tasks
- Add to Completed section with PR #33 reference
- Update Last Updated date

## Evidence

All three conflict modes are fully implemented and tested:
- ✅ Skip mode: Skips existing entries
- ✅ Replace mode: Updates existing entries  
- ✅ Strict mode: Fails on any duplicate

Tests passing:
- `test_import_hosts_skip_mode`
- `test_import_hosts_replace_mode`
- `test_import_hosts_strict_mode`

Implementation: `crates/router-hosts/src/server/commands.rs:895-1020`

Closes #47