### PR TITLE
docs: update status after E2E testing infrastructure merge

### DIFF
--- a/docs/plans/2025-12-01-v1-tasks.md
+++ b/docs/plans/2025-12-01-v1-tasks.md
@@ -22,7 +22,7 @@
 | Export RPC | ✅ Complete | PR #22, 2025-12-04 |
 | Import RPC | ✅ Complete | PR #33, 2025-12-05 |
 | Client CLI | ✅ Complete | PR #36, 2025-12-06 |
-| E2E acceptance tests | ✅ Complete | PR #62, 2025-12-08 |
+| E2E acceptance tests | ✅ Complete | PR #72, 2025-12-08 |
 
 ### E2E Test Status
 
@@ -36,6 +36,13 @@
 | disaster_recovery (2 tests) | ⏸️ Ignored | Blocked on #71 (snapshot JSON output) |
 
 ### Remaining v1.0 Work
+
+#### High Priority - CLI Bugs Blocking E2E Tests
+| Task | Issue | Description |
+|------|-------|-------------|
+| Fix host import clap type mismatch | #69 | Import command has clap type error preventing E2E import/export tests |
+| Fix JSON output missing 'id' field | #70 | CRUD operations missing ID field blocking E2E CRUD workflow tests |
+| Fix snapshot create empty output | #71 | Snapshot create returns empty JSON blocking E2E disaster recovery tests |
 
 #### Medium Priority
 | Task | Issue | Description |
@@ -91,6 +98,13 @@ Issues created from PR #36 code review:
 | Interactive conflict handling | 2025-12-08 | PR #51 - CLI diff display with retry |
 | Snapshot retention | 2025-12-08 | PR #53 - Enforce max_snapshots and max_age |
 | Version conflict tests | 2025-12-08 | PR #55 - Integration tests for retry flow |
+<<<<<<< HEAD
 | RollbackToSnapshot | 2025-12-08 | Snapshot rollback with pre-rollback backup |
 | Snapshot/hooks coverage | 2025-12-08 | PR #59 - Tests for snapshots and hooks |
 | E2E testing infrastructure | 2025-12-08 | PR #62 - Docker + testcontainers + mTLS |
+||||||| parent of b19ff0f (docs: update status after E2E testing infrastructure merge)
+| RollbackToSnapshot | 2025-12-08 | PR #XX - Parse snapshot, recreate entries |
+=======
+| RollbackToSnapshot | 2025-12-08 | PR #63 - Parse snapshot, recreate entries |
+| E2E Testing Infrastructure | 2025-12-08 | PR #72 - testcontainers, runtime cert gen, scenario tests |
+>>>>>>> b19ff0f (docs: update status after E2E testing infrastructure merge)

--- a/docs/plans/2025-12-08-e2e-testing-design.md
+++ b/docs/plans/2025-12-08-e2e-testing-design.md
@@ -1,8 +1,28 @@
 # E2E Acceptance Testing Design
 
 **Date:** 2025-12-08
-**Status:** Approved
+**Status:** Implemented (PR #72)
 **Related:** Pre-v1.0 hardening, security audit preparation
+
+## Implementation Status
+
+**Merged:** 2025-12-08 via PR #72
+
+**What Works:**
+- ✅ testcontainers-based server orchestration
+- ✅ Runtime certificate generation with rcgen
+- ✅ Initial setup scenario (test_initial_deployment)
+- ✅ Auth failure scenarios (test_wrong_ca_rejected, test_self_signed_client_rejected)
+- ✅ Daily operations: search/filter (test_search_and_filter)
+- ✅ Docker CI/E2E integration with Dockerfile.ci
+
+**Ignored Tests (blocked by CLI bugs):**
+- ⏸️ test_crud_workflow - Issue #70 (missing 'id' field in JSON output)
+- ⏸️ test_import_export_roundtrip - Issue #69 (import command clap type mismatch)
+- ⏸️ test_snapshot_and_rollback - Issue #71 (snapshot create returns empty output)
+- ⏸️ test_rollback_creates_backup - Issue #71 (snapshot create returns empty output)
+
+**Next Steps:** Fix issues #69, #70, #71 to enable all E2E scenarios.
 
 ## Overview
 


### PR DESCRIPTION
## Summary

Update documentation to reflect E2E testing infrastructure completion (PR #72).

## Changes

### `docs/plans/2025-12-01-v1-tasks.md`
- ✅ Mark E2E acceptance tests as complete
- 📊 Add detailed E2E test status table showing:
  - 3 passing scenarios (initial_setup, auth_failures, search_and_filter)
  - 4 ignored tests blocked by CLI bugs (#69, #70, #71)
- 🔴 Promote CLI bugs to "High Priority" section (blocking E2E completion)
- 📝 Add E2E testing to completed tasks list with PR #72

### `docs/plans/2025-12-08-e2e-testing-design.md`
- 📍 Update status: "Approved" → "Implemented (PR #72)"
- 📋 Add implementation status section documenting:
  - What works (testcontainers, runtime certs, 3 passing scenarios)
  - Blocked tests with issue numbers
  - Next steps (fix CLI bugs #69, #70, #71)

## Motivation

After PR #72 merged, documentation needed to reflect:
1. What's actually implemented and working
2. What's blocked and why (CLI bugs)
3. Clear next steps for completing E2E coverage

The CLI bugs were originally "nice to have" enhancements, but now block E2E test completion - promoted to high priority.

🤖 Generated with [Claude Code](https://claude.com/claude-code)