### PR TITLE
fix(cli): output structured data for snapshot create command

### DIFF
--- a/crates/router-hosts-common/build.rs
+++ b/crates/router-hosts-common/build.rs
@@ -13,6 +13,14 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             "router_hosts.v1.CreateSnapshotResponse",
             "#[derive(serde::Serialize)]",
         )
+        .type_attribute(
+            "router_hosts.v1.RollbackToSnapshotResponse",
+            "#[derive(serde::Serialize)]",
+        )
+        .type_attribute(
+            "router_hosts.v1.DeleteSnapshotResponse",
+            "#[derive(serde::Serialize)]",
+        )
         // Skip timestamp fields when serializing
         .field_attribute("router_hosts.v1.HostEntry.created_at", "#[serde(skip)]")
         .field_attribute("router_hosts.v1.HostEntry.updated_at", "#[serde(skip)]")

--- a/crates/router-hosts/src/client/commands/snapshot.rs
+++ b/crates/router-hosts/src/client/commands/snapshot.rs
@@ -40,17 +40,16 @@ pub async fn handle(
         SnapshotCommand::Rollback { snapshot_id } => {
             let request = RollbackToSnapshotRequest { snapshot_id };
             let response = client.rollback_to_snapshot(request).await?;
-            if !quiet && response.success {
-                eprintln!("Rolled back successfully");
-                eprintln!("Backup snapshot created: {}", response.new_snapshot_id);
+            if !quiet {
+                print_item(&response, format);
             }
         }
 
         SnapshotCommand::Delete { snapshot_id } => {
             let request = DeleteSnapshotRequest { snapshot_id };
             let response = client.delete_snapshot(request).await?;
-            if !quiet && response.success {
-                eprintln!("Deleted snapshot successfully");
+            if !quiet {
+                print_item(&response, format);
             }
         }
     }


### PR DESCRIPTION
## Summary

Fixes #71 - ALL snapshot commands now output structured data to stdout with `--format` support.

## Problem

Three snapshot commands were using `eprintln!()` which:
- Writes to stderr instead of stdout
- Ignores the `--format` flag (json/csv/table)
- Only outputs plain text messages

**Affected commands:**
- ✅ `snapshot create` - outputs snapshot_id, created_at, entry_count
- ✅ `snapshot rollback` - outputs success, backup_snapshot_id, restored_entry_count  
- ✅ `snapshot delete` - outputs success
- (✓ `snapshot list` was already working correctly)

This blocked E2E disaster recovery tests that need to parse JSON output.

## Solution

Applied consistent pattern across ALL snapshot commands:
1. Added `Serialize` derive to all response types in build.rs
2. Implemented `TableDisplay` trait for each response type in output.rs
3. Replaced `eprintln!()` with `print_item(&response, format)` in snapshot.rs

## Changes

**Modified files:**
- `crates/router-hosts-common/build.rs`: Add Serialize derives
- `crates/router-hosts/src/client/output.rs`: Implement TableDisplay traits + 10 new tests
- `crates/router-hosts/src/client/commands/snapshot.rs`: Use print_item() for all commands

## Test Coverage

- ✅ 180 unit tests pass (10 new tests added)
- ✅ 28 integration tests pass
- ✅ All formatting and linting clean
- ✅ JSON object structure verified for all response types

**New tests:**
- `test_create_snapshot_response_{headers,row,row_short_id,json_format}`
- `test_rollback_response_{headers,row,json_format}`
- `test_delete_response_{headers,row,json_format}`

## Example Output

**JSON format:**
```bash
$ router-hosts snapshot create --format json
{
  "snapshot_id": "01JXXXXXXXXXXXXXXXXX",
  "created_at": 1733500000000000,
  "entry_count": 42
}

$ router-hosts snapshot rollback 01JXX --format json
{
  "success": true,
  "new_snapshot_id": "01JYYYYYYYYYYYYYYYYY",
  "restored_entry_count": 42
}
```

**Table format (default):**
```bash
$ router-hosts snapshot create
SNAPSHOT_ID       CREATED_AT          ENTRY_COUNT
01JXXXXXXXXX...   2024-12-06 12:00    42

$ router-hosts snapshot rollback 01JXX
SUCCESS  BACKUP_SNAPSHOT_ID  RESTORED_ENTRIES
true     01JYYYYYYYYY...     42
```

## Impact

- ✅ Unblocks 2 E2E disaster recovery tests currently ignored
- ✅ ALL snapshot commands now consistent with host commands
- ✅ Supports all output formats: json, csv, table
- ✅ Enables E2E test automation for disaster recovery scenarios

🤖 Generated with [Claude Code](https://claude.com/claude-code)