### PR TITLE
docs: update E2E test status after PR #80 merge

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ task e2e:scenario -- daily_operations
 
 ## Status
 
-✅ **v1.0 Core Complete** - All features implemented, 6/8 E2E tests passing (2 awaiting PR #80 merge)
+✅ **v1.0 Core Complete** - All features implemented, 8/8 E2E tests passing
 
 **Ready for testing:**
 - ✅ Client CLI with all commands (host, snapshot, config)
@@ -114,7 +114,7 @@ task e2e:scenario -- daily_operations
 - ✅ Import/Export (hosts, JSON, CSV formats)
 - ✅ Snapshots with rollback and retention
 - ✅ mTLS authentication
-- ✅ E2E test coverage (disaster recovery tests pending PR #80)
+- ✅ Full E2E test coverage
 
 See [v1.0 Task List](docs/plans/2025-12-01-v1-tasks.md) for implementation details.
 

--- a/docs/plans/2025-12-01-v1-tasks.md
+++ b/docs/plans/2025-12-01-v1-tasks.md
@@ -26,7 +26,7 @@
 
 ### E2E Test Status
 
-**6/8 E2E tests passing** (2 awaiting PR #80 merge)
+**All 8 E2E tests passing** ✅
 
 | Test Scenario | Status | Notes |
 |--------------|--------|-------|
@@ -35,7 +35,7 @@
 | search_and_filter | ✅ Passing | Host search functionality |
 | crud_workflow | ✅ Passing | Fixed in PR #75 |
 | import_export_roundtrip | ✅ Passing | Fixed in PR #76 |
-| disaster_recovery (2 tests) | ⏸️ Awaiting merge | Fixed in PR #79, PR #80 pending |
+| disaster_recovery (2 tests) | ✅ Passing | Fixed in PR #79, re-enabled in PR #80 |
 
 ### Post-v1.0 Enhancements
 
@@ -138,4 +138,5 @@ Issues created from PR #36 code review:
 | Snapshot/hooks coverage | 2025-12-08 | PR #59 - Tests for snapshots and hooks |
 | E2E testing infrastructure | 2025-12-08 | PR #72 - Docker + testcontainers + mTLS + scenario tests |
 | CLI JSON output bug fixes | 2025-12-09 | PRs #75, #76, #79 - Fixed JSON output for all commands |
-| E2E disaster recovery tests | 2025-12-09 | PR #80 (pending merge) - Re-enable disaster recovery E2E tests |
+| E2E disaster recovery tests | 2025-12-09 | PR #80 - Re-enabled disaster recovery E2E tests (8/8 passing) |
+| Documentation updates | 2025-12-10 | PR #81 - Updated project status to reflect v1.0 complete |


### PR DESCRIPTION
## Summary

Update documentation to reflect that PR #80 has merged and all 8/8 E2E tests are now passing on main branch.

## Changes

### README.md
- Update status: "6/8 E2E tests passing (2 awaiting PR #80 merge)" → "8/8 E2E tests passing"
- Simplify E2E coverage line: "disaster recovery tests pending PR #80" → "Full E2E test coverage"

### docs/plans/2025-12-01-v1-tasks.md
- Update E2E test count header: "6/8" → "All 8 E2E tests passing ✅"
- Change disaster_recovery status: "⏸️ Awaiting merge" → "✅ Passing"
- Update PR #80 entry: Remove "(pending merge)", add note "8/8 passing"
- Add PR #81 to completed work (documentation updates from yesterday)

## Verification

Verified on main branch:
- All 8 E2E tests enabled (no `#[ignore]` markers)
- disaster_recovery.rs tests re-enabled in PR #80
- Tests passing in CI

## Context

This completes the documentation accuracy work from PR #81. That PR was conservative (showing 6/8) because PR #80 hadn't merged yet. Now that both PRs are merged, documentation reflects the complete v1.0 status.

## References

Refs #78 (CHANGELOG for v0.1.0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)