### PR TITLE
docs: document Renovate branch handling policy

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -632,3 +632,5 @@ cargo test -p router-hosts-e2e --release test_import_export_roundtrip
 - `docker:build` compiles Linux binary inside Docker (works cross-platform)
 - `docker:build-ci` copies host binary (fast on Linux CI, broken on macOS)
 - Tests need `ROUTER_HOSTS_IMAGE=...dev` to use locally built image
+
+**Important:** Never push commits directly to Renovate-originated branches. Renovate manages these branches automatically and will force-push updates. Always create a separate branch for any manual fixes.


### PR DESCRIPTION
## Summary

Adds documentation to CLAUDE.md clarifying that manual commits should never be pushed directly to Renovate-originated branches.

## Why

Renovate automatically manages its branches and will force-push updates. Pushing manual commits to these branches creates conflicts and confusion. Manual fixes for Renovate dependency updates should always be on separate branches with their own PRs.

## Changes

- Added note to macOS E2E Testing section explaining Renovate branch policy
- Clarifies that fixes should be on separate branches

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>