### PR TITLE
fix(ci): use imagetools for multi-arch manifest with attestations

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -96,6 +96,9 @@ jobs:
     steps:
       - uses: runs-on/action@v2
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Log in to Container Registry
         uses: docker/login-action@v3
         with:
@@ -103,22 +106,21 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Create and push manifest
+      - name: Create and push multi-arch manifest
         env:
           REGISTRY: ${{ env.REGISTRY }}
           IMAGE_NAME: ${{ env.IMAGE_NAME }}
           GITHUB_SHA: ${{ github.sha }}
           GITHUB_REF: ${{ github.ref }}
         run: |
-          docker manifest create "${REGISTRY}/${IMAGE_NAME}:${GITHUB_SHA}" \
+          # Use imagetools to create multi-arch manifest (preserves attestations)
+          docker buildx imagetools create -t "${REGISTRY}/${IMAGE_NAME}:${GITHUB_SHA}" \
             "${REGISTRY}/${IMAGE_NAME}:${GITHUB_SHA}-amd64" \
             "${REGISTRY}/${IMAGE_NAME}:${GITHUB_SHA}-arm64"
-          docker manifest push "${REGISTRY}/${IMAGE_NAME}:${GITHUB_SHA}"
 
           # Also tag as latest on main branch
           if [ "${GITHUB_REF}" = "refs/heads/main" ]; then
-            docker manifest create "${REGISTRY}/${IMAGE_NAME}:latest" \
+            docker buildx imagetools create -t "${REGISTRY}/${IMAGE_NAME}:latest" \
               "${REGISTRY}/${IMAGE_NAME}:${GITHUB_SHA}-amd64" \
               "${REGISTRY}/${IMAGE_NAME}:${GITHUB_SHA}-arm64"
-            docker manifest push "${REGISTRY}/${IMAGE_NAME}:latest"
           fi


### PR DESCRIPTION
## Summary
- Replace `docker manifest` with `docker buildx imagetools create` to fix multi-arch manifest creation
- **Preserves** provenance attestations for SLSA supply chain security

## Problem
The Docker CI workflow was failing with:
```
ghcr.io/fzymgc-house/router-hosts:...-amd64 is a manifest list
```

`docker/build-push-action@v6` creates OCI image indices with attestations by default. The legacy `docker manifest create` command cannot handle these indices.

## Solution
Use `docker buildx imagetools create` which:
- Handles modern OCI image indices with attestations
- Merges platform-specific images into a proper multi-arch manifest
- Preserves SLSA provenance data (unlike disabling `provenance`)

## Changes
- Add `docker/setup-buildx-action@v3` to the manifest job
- Replace `docker manifest create/push` with `docker buildx imagetools create -t`
- Keep attestations enabled (removed earlier `provenance: false` attempt)

## Test plan
- [ ] CI Docker workflow passes
- [ ] Multi-arch manifest created successfully
- [ ] Attestations preserved: `docker buildx imagetools inspect ghcr.io/fzymgc-house/router-hosts:latest`

🤖 Generated with [Claude Code](https://claude.com/claude-code)