### PR TITLE
docs: update documentation to reflect SQLite backend completion

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -496,9 +496,10 @@ Four crates in a Cargo workspace:
 
 2. **router-hosts-storage** - Storage abstraction layer
    - `Storage` trait defining EventStore, SnapshotStore, and HostProjection
-   - DuckDB backend implementation
+   - DuckDB backend implementation (default, feature-rich)
+   - SQLite backend implementation (lightweight, embedded)
    - Shared test suite for backend compliance (42 tests)
-   - Designed for future backend additions (SQLite, PostgreSQL, etc.)
+   - Designed for future backend additions (PostgreSQL, etc.)
 
 3. **router-hosts** - Unified binary (client and server modes)
    - **Client mode (default):** CLI interface using clap, gRPC client wrapper, command handlers

--- a/docs/plans/2025-12-14-storage-abstraction-impl.md
+++ b/docs/plans/2025-12-14-storage-abstraction-impl.md
@@ -27,8 +27,9 @@
 | 4 | 4.2: Update server to use storage abstraction | ✅ Complete | PR #104 |
 | 5 | 5.1: Remove old db module | ✅ Complete | PR #104 |
 | 5 | 5.2: Add shared test suite | ✅ Complete | PR #110 |
+| 6 | 6.1: Implement SQLite backend | ✅ Complete | PR #114 |
 
-**Status:** ✅ **All tasks complete** - Storage abstraction fully implemented
+**Status:** ✅ **All tasks complete** - Storage abstraction fully implemented with DuckDB and SQLite backends
 
 **Last Updated:** 2025-12-15
 


### PR DESCRIPTION
## Summary
- Add SQLite backend task (6.1) to storage abstraction plan status table
- Update CLAUDE.md workspace structure to show SQLite is implemented
- PostgreSQL remains as future work

This is a documentation-only change to reflect the completed SQLite backend work from PR #114.

🤖 Generated with [Claude Code](https://claude.com/claude-code)