### PR TITLE
docs: update documentation for multi-backend storage support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -496,10 +496,10 @@ Four crates in a Cargo workspace:
 
 2. **router-hosts-storage** - Storage abstraction layer
    - `Storage` trait defining EventStore, SnapshotStore, and HostProjection
-   - DuckDB backend implementation (default, feature-rich)
-   - SQLite backend implementation (lightweight, embedded)
+   - DuckDB backend (default, embedded, feature-rich)
+   - SQLite backend (lightweight, embedded, single-file)
+   - PostgreSQL backend (multi-instance, cloud deployments, connection pooling)
    - Shared test suite for backend compliance (42 tests)
-   - Designed for future backend additions (PostgreSQL, etc.)
 
 3. **router-hosts** - Unified binary (client and server modes)
    - **Client mode (default):** CLI interface using clap, gRPC client wrapper, command handlers
@@ -513,7 +513,7 @@ Four crates in a Cargo workspace:
 ### Key Design Decisions
 
 **Event Sourcing:**
-- All changes stored as immutable events in DuckDB
+- All changes stored as immutable events in the storage backend
 - Current state reconstructed from event log (CQRS pattern)
 - Complete audit trail and time-travel query capability
 - Optimistic concurrency via event versions
@@ -534,7 +534,7 @@ Four crates in a Cargo workspace:
 - Post-edit hooks run after success/failure
 
 **Versioning:**
-- DuckDB stores snapshots of /etc/hosts at points in time
+- Storage backend stores snapshots of /etc/hosts at points in time
 - Configurable retention (max count and max age)
 - Rollback creates snapshot before restoring old version
 
@@ -549,7 +549,7 @@ Four crates in a Cargo workspace:
 **Server requires:**
 - `hosts_file_path` setting (no default) - prevents accidental overwrites
 - TLS certificate paths
-- DuckDB path
+- Storage backend configuration (DuckDB path, SQLite path, or PostgreSQL URL)
 - Optional: retention policy, hooks, timeout settings
 
 **Client:**
@@ -561,8 +561,10 @@ Four crates in a Cargo workspace:
 ### Storage Layer
 
 - **Storage trait** in `router-hosts-storage` abstracts database operations
-- Currently uses **DuckDB** backend (embedded, single file, no daemon)
-- Ideal for embedded/router environments
+- **Available backends:**
+  - **DuckDB** (default): Embedded, single file, feature-rich analytics
+  - **SQLite**: Lightweight embedded, single file, wide compatibility
+  - **PostgreSQL**: Multi-instance deployments, connection pooling, cloud-ready
 - Use in-memory mode for tests: `DuckDbStorage::new(":memory:")`
 - Shared test suite validates any `Storage` implementation (42 tests)
 

--- a/docs/plans/2025-12-15-postgres-backend-impl.md
+++ b/docs/plans/2025-12-15-postgres-backend-impl.md
@@ -4,9 +4,36 @@
 
 **Goal:** Implement PostgreSQL storage backend using sqlx with connection pooling.
 
-**Architecture:** True async PostgreSQL backend using sqlx's PgPool. Window functions with IGNORE NULLS like DuckDB. Testcontainers for testing.
+**Architecture:** True async PostgreSQL backend using sqlx's PgPool. Uses DISTINCT ON with CTEs instead of IGNORE NULLS (PostgreSQL doesn't support IGNORE NULLS until version 19). Testcontainers for testing.
 
 **Tech Stack:** sqlx 0.8, tokio, testcontainers-modules
+
+---
+
+## Status
+
+| Task | Description | Status | PR |
+|------|-------------|--------|-----|
+| 1 | Add Dependencies | ✅ Complete | PR #116 |
+| 2 | Create Module Structure | ✅ Complete | PR #116 |
+| 3 | Implement Schema | ✅ Complete | PR #116 |
+| 4 | Implement EventStore | ✅ Complete | PR #116 |
+| 5 | Implement SnapshotStore | ✅ Complete | PR #116 |
+| 6 | Implement HostProjection | ✅ Complete | PR #116 |
+| 7 | Implement Storage Trait | ✅ Complete | PR #116 |
+| 8 | Update lib.rs Exports | ✅ Complete | PR #116 |
+| 9 | Create Integration Tests | ✅ Complete | PR #116 |
+| 10 | Update CI Workflow | ✅ Complete | PR #116 |
+
+**Status:** ✅ **All tasks complete** - PostgreSQL backend fully implemented
+
+**Implementation Notes:**
+- PostgreSQL doesn't support `IGNORE NULLS` in window functions until version 19
+- Implemented using `DISTINCT ON` with CTEs as PostgreSQL-compatible alternative
+- Tested with PostgreSQL 17 via testcontainers
+- All 42 shared test suite tests pass
+
+**Last Updated:** 2025-12-15
 
 ---
 


### PR DESCRIPTION
## Summary
- Add completion status to PostgreSQL implementation plan (PR #116)
- Update CLAUDE.md to reflect all three storage backends:
  - DuckDB (default, embedded, feature-rich)
  - SQLite (lightweight, embedded)
  - PostgreSQL (multi-instance, cloud deployments)
- Make storage references backend-agnostic throughout CLAUDE.md

## Test plan
- [x] Documentation only - no code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)