### PR TITLE
feat(ci): add version tags to Docker images on release

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -3,6 +3,7 @@ name: Docker
 on:
   push:
     branches: [main]
+    tags: ['v*']
   pull_request:
     branches: [main]
 
@@ -140,15 +141,29 @@ jobs:
           IMAGE_NAME: ${{ env.BASE_IMAGE_NAME }}${{ matrix.variant.suffix }}
           GITHUB_SHA: ${{ github.sha }}
           GITHUB_REF: ${{ github.ref }}
+          GITHUB_REF_NAME: ${{ github.ref_name }}
         run: |
           # Use imagetools to create multi-arch manifest (preserves attestations)
           docker buildx imagetools create -t "${REGISTRY}/${IMAGE_NAME}:${GITHUB_SHA}" \
             "${REGISTRY}/${IMAGE_NAME}:${GITHUB_SHA}-amd64" \
             "${REGISTRY}/${IMAGE_NAME}:${GITHUB_SHA}-arm64"
 
-          # Also tag as latest on main branch
+          # Tag as latest on main branch
           if [ "${GITHUB_REF}" = "refs/heads/main" ]; then
             docker buildx imagetools create -t "${REGISTRY}/${IMAGE_NAME}:latest" \
+              "${REGISTRY}/${IMAGE_NAME}:${GITHUB_SHA}-amd64" \
+              "${REGISTRY}/${IMAGE_NAME}:${GITHUB_SHA}-arm64"
+          fi
+
+          # Tag with version on tag push (e.g., v0.6.0 -> 0.6.0 and v0.6.0)
+          if [[ "${GITHUB_REF}" == refs/tags/v* ]]; then
+            # Full tag (v0.6.0)
+            docker buildx imagetools create -t "${REGISTRY}/${IMAGE_NAME}:${GITHUB_REF_NAME}" \
+              "${REGISTRY}/${IMAGE_NAME}:${GITHUB_SHA}-amd64" \
+              "${REGISTRY}/${IMAGE_NAME}:${GITHUB_SHA}-arm64"
+            # Version without v prefix (0.6.0)
+            VERSION="${GITHUB_REF_NAME#v}"
+            docker buildx imagetools create -t "${REGISTRY}/${IMAGE_NAME}:${VERSION}" \
               "${REGISTRY}/${IMAGE_NAME}:${GITHUB_SHA}-amd64" \
               "${REGISTRY}/${IMAGE_NAME}:${GITHUB_SHA}-arm64"
           fi


### PR DESCRIPTION
## Summary

- Trigger Docker workflow on version tag pushes (`v*`)
- Create version-tagged images when releasing:
  - `v0.6.0` - full tag
  - `0.6.0` - version without prefix
- Both standard and duckdb variants get version tags

## Note

For v0.6.0, the images will need to be manually tagged since this workflow change wasn't in that release. After this PR merges, future releases will automatically create version-tagged Docker images.

## Test Plan

- [ ] CI passes
- [ ] After merge, manually tag v0.6.0 images or wait for next release

🤖 Generated with [Claude Code](https://claude.com/claude-code)