### PR TITLE
refactor(hooks): address PR #166 review suggestions

### DIFF
--- a/crates/router-hosts/src/server/hooks.rs
+++ b/crates/router-hosts/src/server/hooks.rs
@@ -25,12 +25,16 @@ use super::config::HookDefinition;
 
 #[derive(Debug, Error)]
 pub enum HookError {
+    /// Hook process exceeded the configured timeout and was killed
     #[error("Hook timed out after {0} seconds")]
     Timeout(u64),
 
-    #[error("Hook failed with exit code {0}: {1}")]
+    /// Hook process exited with non-zero exit code
+    /// Parameters: (exit_code, hook_name)
+    #[error("Hook '{1}' failed with exit code {0}")]
     Failed(i32, String),
 
+    /// IO error spawning or waiting for hook process
     #[error("IO error: {0}")]
     Io(#[from] std::io::Error),
 }


### PR DESCRIPTION
## Summary

These changes were committed to PR #166 after it was merged. This PR applies the review suggestions that didn't make it into the squash merge.

## Changes

- Add doc comments to `HookError` variants explaining each error type
- Improve kebab-case error message with full format requirements
- Make `#[must_use]` message on `validate()` more specific
- Add test verifying validation order (invalid name detected before duplicate check)
- Update error message format to quote hook name for clarity

## Context

PR #166 was merged at 16:37:45 UTC. The following commits were pushed after the merge:
- `92a0512` - fix(server): use 32 days in cert expiry boundary test (**already in merge**)
- `6a284b6` - refactor(hooks): address review suggestions for clarity (**this PR**)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>