### PR TITLE
perf(ci): remove unnecessary rust-setup from e2e job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -188,11 +188,7 @@ jobs:
 
       - uses: actions/checkout@v6
 
-      - name: Setup Rust environment
-        uses: ./.github/actions/rust-setup
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-
+      # Note: No rust-setup needed - binary is pre-built from 'build' job
       - name: Install Task
         uses: arduino/setup-task@v2
 
@@ -206,7 +202,7 @@ jobs:
         run: chmod +x target/release/router-hosts
 
       - name: Build CI Docker image
-        run: task docker:build-ci IMAGE_NAME=router-hosts IMAGE_TAG=ci
+        run: task docker:build-e2e IMAGE_NAME=router-hosts IMAGE_TAG=ci
 
       - name: Verify Docker image runs
         run: |

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -129,6 +129,16 @@ tasks:
       - docker build -f Dockerfile.ci -t {{.IMAGE_NAME}}:{{.IMAGE_TAG}} -t {{.LOCAL_IMAGE}} .
       - rm router-hosts
 
+  docker:build-e2e:
+    desc: Build Docker image from existing binary (no build step, for CI artifact reuse)
+    preconditions:
+      - test -f target/release/router-hosts
+    cmds:
+      # Copy binary to root to avoid .dockerignore excluding target/
+      - cp target/release/router-hosts router-hosts
+      - docker build -f Dockerfile.ci -t {{.IMAGE_NAME}}:{{.IMAGE_TAG}} -t {{.LOCAL_IMAGE}} .
+      - rm router-hosts
+
   docker:run:
     desc: Run server container (requires certs in ./dev/certs/)
     cmds:


### PR DESCRIPTION
## Summary

E2E job uses pre-built binary from artifact and doesn't need the Rust toolchain.

**Changes:**
- Add `docker:build-e2e` task (skips `build:release` dep, has precondition check)
- Remove `rust-setup` from e2e job (saves ~1-2 min per run)
- Use `docker:build-e2e` instead of `docker:build-ci`

**Why this matters:**
- `docker:build-ci` has `deps: ["build:release"]` which triggers unnecessary cargo compilation
- E2E job downloads pre-built binary from the `build` job's artifact
- Installing Rust toolchain, protoc, buf, and cache setup is wasted time

**Impact:** ~1-2 min faster E2E jobs

## Test plan

- [ ] CI passes (e2e job completes without rust-setup)
- [ ] Verify `docker:build-e2e` precondition catches missing binary

🤖 Generated with [Claude Code](https://claude.com/claude-code)