### PR TITLE
chore: release v0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.0] - 2025-12-30
+
+### Added
+
+- **XDG config auto-discovery**: Client now automatically searches for config files in XDG-compliant locations (`~/.config/router-hosts/`, `/etc/router-hosts/`) when no explicit config is provided
+
+### Changed
+
+- **CI/CD improvements**: Optimized build parallelization and added Helm chart OCI registry publishing workflow
+
 ## [0.7.0] - 2025-12-30
 
 ### Breaking Changes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3757,7 +3757,7 @@ dependencies = [
 
 [[package]]
 name = "router-hosts"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3813,7 +3813,7 @@ dependencies = [
 
 [[package]]
 name = "router-hosts-common"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "chrono",
  "dlprotoc",
@@ -3831,7 +3831,7 @@ dependencies = [
 
 [[package]]
 name = "router-hosts-duckdb"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "router-hosts",
@@ -3841,7 +3841,7 @@ dependencies = [
 
 [[package]]
 name = "router-hosts-e2e"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "assert_cmd",
  "predicates",
@@ -3859,7 +3859,7 @@ dependencies = [
 
 [[package]]
 name = "router-hosts-operator"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3891,7 +3891,7 @@ dependencies = [
 
 [[package]]
 name = "router-hosts-storage"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.7.0"
+version = "0.8.0"
 edition = "2021"
 authors = ["fzymgc-house"]
 license = "MIT"

--- a/charts/router-hosts-operator/Chart.yaml
+++ b/charts/router-hosts-operator/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: router-hosts-operator
 description: Kubernetes operator for syncing Ingress hostnames to router-hosts
 type: application
-version: 0.7.0
-appVersion: 0.7.0
+version: 0.8.0
+appVersion: 0.8.0
 home: https://github.com/fzymgc-house/router-hosts
 sources:
   - https://github.com/fzymgc-house/router-hosts


### PR DESCRIPTION
## Summary

- Bump workspace version to 0.8.0
- Update Helm chart version to 0.8.0
- Update CHANGELOG with release notes

## Changes since v0.7.0

- **XDG config auto-discovery**: Client now automatically searches for config files in XDG-compliant locations
- **CI/CD improvements**: Optimized build parallelization and added Helm chart OCI registry publishing workflow

## Post-merge

After merging, create and push the tag:
```bash
git checkout main && git pull
git tag v0.8.0
git push origin v0.8.0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)