### PR TITLE
ci(ghcr): disable dry-run mode for image cleanup

### DIFF
--- a/.github/workflows/cleanup-images.yml
+++ b/.github/workflows/cleanup-images.yml
@@ -93,5 +93,5 @@ jobs:
           # See: https://github.com/snok/container-retention-policy#image-tags
           image-tags: "!latest !v*.*.* *"
 
-          # Enable dry-run for safe testing (change to false for production)
-          dry-run: true
+          # Dry-run disabled after successful validation (see #88)
+          dry-run: false


### PR DESCRIPTION
## Summary

- Disables dry-run mode for GHCR image cleanup workflow

## Context

Validation completed successfully over 3+ weeks with multiple successful workflow runs (see #88). The workflow correctly identifies images to delete while protecting:
- `latest` tag
- Semantic version tags (`v*.*.*`)
- Keeps 3 most recent images as safety net

## Test Plan

- [x] Verified multiple dry-run executions succeeded
- [x] Confirmed protected tags are not flagged for deletion
- [ ] Monitor first production run (next scheduled: Sunday 2 AM UTC)

Closes #88

🤖 Generated with [Claude Code](https://claude.com/claude-code)