### PR TITLE
chore: add coverage directory to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,7 +19,7 @@ target/
 
 # Build artifacts
 *.pdb
-.worktrees/
+coverage/
 
 # Temporary binary for CI Docker build
 /router-hosts


### PR DESCRIPTION
## Summary

- Adds `coverage/` to .gitignore (generated by cargo-tarpaulin)
- Removes duplicate `.worktrees/` entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)