### PR TITLE
fix(ci): use simple release-type for Cargo workspace

### DIFF
--- a/docs/plans/2025-12-31-release-please-migration-design.md
+++ b/docs/plans/2025-12-31-release-please-migration-design.md
@@ -64,7 +64,7 @@ flowchart TD
 ```json
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
-  "release-type": "rust",
+  "release-type": "simple",
   "include-component-in-tag": false,
   "include-v-in-tag": true,
   "bump-minor-pre-major": true,
@@ -83,6 +83,11 @@ flowchart TD
   ],
   "extra-files": [
     {
+      "type": "toml",
+      "path": "Cargo.toml",
+      "jsonpath": "$.workspace.package.version"
+    },
+    {
       "type": "yaml",
       "path": "charts/router-hosts-operator/Chart.yaml",
       "jsonpath": "$.version"
@@ -100,6 +105,8 @@ flowchart TD
   }
 }
 ```
+
+**Note:** Using `simple` release-type instead of `rust` because the Cargo workspace uses `version.workspace = true` inheritance. The `rust` type doesn't handle workspace inheritance properly.
 
 ### .release-please-manifest.json
 

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
-  "release-type": "rust",
+  "release-type": "simple",
   "include-component-in-tag": false,
   "include-v-in-tag": true,
   "bump-minor-pre-major": true,
@@ -18,6 +18,11 @@
     {"type": "chore", "section": "Miscellaneous", "hidden": true}
   ],
   "extra-files": [
+    {
+      "type": "toml",
+      "path": "Cargo.toml",
+      "jsonpath": "$.workspace.package.version"
+    },
     {
       "type": "yaml",
       "path": "charts/router-hosts-operator/Chart.yaml",


### PR DESCRIPTION
## Summary

The `rust` release-type in release-please doesn't support Cargo workspaces using `version.workspace = true` inheritance. This caused the workflow to fail with:

```
##[error]release-please failed: value at path package.version is not tagged
```

## Changes

- Switch from `rust` to `simple` release-type
- Add TOML updater for `$.workspace.package.version` in root Cargo.toml
- Update design doc with note about workspace inheritance

## Test Plan

- [ ] Verify release-please workflow runs successfully on merge
- [ ] Verify release PR is created for pending commits

🤖 Generated with [Claude Code](https://claude.com/claude-code)