### PR TITLE
fix(ci): enable GitHub Release creation for tag pushing

### DIFF
--- a/docs/contributing/releasing.md
+++ b/docs/contributing/releasing.md
@@ -251,8 +251,8 @@ release-please uses semantic versioning with `v` prefix:
 Creates/updates release PRs and pushes tags when merged. Configuration in `release-please-config.json`.
 
 Key settings:
-- `skip-github-release: true` - cargo-dist handles GitHub Release creation
-- `extra-files` - Syncs Chart.yaml version and appVersion
+- `skip-github-release: false` - release-please creates GitHub Release and pushes tag, cargo-dist then adds binaries
+- `extra-files` - Syncs Cargo.toml workspace version and Chart.yaml version/appVersion
 
 ### v-release.yml
 

--- a/docs/plans/2025-12-31-release-please-migration-design.md
+++ b/docs/plans/2025-12-31-release-please-migration-design.md
@@ -15,7 +15,7 @@ Migrate from release-plz to Google's release-please for release automation. rele
 | Tag format | `v0.8.1` | Simple, no component prefix |
 | Chart.yaml sync | extra-files | Automatic via jsonpath |
 | Changelog | release-please owns | Single source of truth |
-| GitHub Release | cargo-dist creates | Uses CHANGELOG.md content |
+| GitHub Release | release-please creates, cargo-dist updates | release-please adds notes, cargo-dist adds binaries |
 | Authentication | GitHub App | Can trigger downstream workflows |
 
 ## Architecture
@@ -69,7 +69,7 @@ flowchart TD
   "include-v-in-tag": true,
   "bump-minor-pre-major": true,
   "bump-patch-for-minor-pre-major": true,
-  "skip-github-release": true,
+  "skip-github-release": false,
   "changelog-sections": [
     {"type": "feat", "section": "Features"},
     {"type": "fix", "section": "Bug Fixes"},

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -5,7 +5,7 @@
   "include-v-in-tag": true,
   "bump-minor-pre-major": true,
   "bump-patch-for-minor-pre-major": true,
-  "skip-github-release": true,
+  "skip-github-release": false,
   "changelog-sections": [
     {"type": "feat", "section": "Features"},
     {"type": "fix", "section": "Bug Fixes"},


### PR DESCRIPTION
## Summary

- Changed `skip-github-release` from `true` to `false` in release-please config
- This fixes the issue where release-please would create and merge the release PR but not push the version tag

## Problem

When `skip-github-release: true`:
- Release PR #197 was created and merged
- But no `v0.8.1` tag was pushed
- This is because `skip-github-release` prevents **both** GitHub Release creation **and** tag pushing

## Solution

Setting `skip-github-release: false` allows:
1. release-please to push the version tag on PR merge
2. release-please to create the GitHub Release with changelog
3. cargo-dist (v-release.yml) to add binaries to the existing release

## Test Plan

- [ ] Merge this PR
- [ ] Verify release-please creates a new release PR for the next version
- [ ] When that PR merges, verify tag is pushed and v-release.yml triggers

🤖 Generated with [Claude Code](https://claude.com/claude-code)