### PR TITLE
fix(ci): extract tarball with --strip-components to fix docs deployment

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -51,7 +51,8 @@ jobs:
           gh release download "$VERSION" \
             --pattern 'router-hosts-x86_64-unknown-linux-gnu.tar.xz' \
             --dir /tmp
-          tar -xJf /tmp/router-hosts-x86_64-unknown-linux-gnu.tar.xz -C /tmp
+          # Extract with --strip-components=1 to remove the top-level directory
+          tar -xJf /tmp/router-hosts-x86_64-unknown-linux-gnu.tar.xz -C /tmp --strip-components=1
           chmod +x /tmp/router-hosts
           /tmp/router-hosts --version
 


### PR DESCRIPTION
## Summary

- Fixes docs deployment failure caused by tarball directory structure
- Release tarballs contain a top-level directory (e.g., `router-hosts-x86_64-unknown-linux-gnu/`)
- Without `--strip-components=1`, the binary ends up in a subdirectory instead of `/tmp`

## Problem

The docs deployment was failing with:
```
chmod: cannot access '/tmp/router-hosts': No such file or directory
```

This is because the tarball structure is:
```
router-hosts-x86_64-unknown-linux-gnu/
├── CHANGELOG.md
├── README.md
└── router-hosts
```

And tar extracted it to `/tmp/router-hosts-x86_64-unknown-linux-gnu/router-hosts`.

## Solution

Add `--strip-components=1` to remove the top-level directory during extraction.

## Test plan

- [ ] Merge and verify docs.yml workflow succeeds on next release

🤖 Generated with [Claude Code](https://claude.com/claude-code)