### PR TITLE
fix(operator): bind health server to 0.0.0.0 for Kubernetes probes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3757,7 +3757,7 @@ dependencies = [
 
 [[package]]
 name = "router-hosts"
-version = "0.8.0"
+version = "0.8.6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3813,7 +3813,7 @@ dependencies = [
 
 [[package]]
 name = "router-hosts-common"
-version = "0.8.0"
+version = "0.8.6"
 dependencies = [
  "chrono",
  "dlprotoc",
@@ -3831,7 +3831,7 @@ dependencies = [
 
 [[package]]
 name = "router-hosts-duckdb"
-version = "0.8.0"
+version = "0.8.6"
 dependencies = [
  "anyhow",
  "router-hosts",
@@ -3841,7 +3841,7 @@ dependencies = [
 
 [[package]]
 name = "router-hosts-e2e"
-version = "0.8.0"
+version = "0.8.6"
 dependencies = [
  "assert_cmd",
  "predicates",
@@ -3859,7 +3859,7 @@ dependencies = [
 
 [[package]]
 name = "router-hosts-operator"
-version = "0.8.0"
+version = "0.8.6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3892,7 +3892,7 @@ dependencies = [
 
 [[package]]
 name = "router-hosts-storage"
-version = "0.8.0"
+version = "0.8.6"
 dependencies = [
  "async-trait",
  "chrono",

--- a/crates/router-hosts-operator/src/health.rs
+++ b/crates/router-hosts-operator/src/health.rs
@@ -68,9 +68,10 @@ pub async fn run_health_server<C: RouterHostsClientTrait + Send + Sync + 'static
         .route("/readyz", get(readyz::<C>))
         .with_state(state.clone());
 
-    // Bind to localhost only - health endpoints should only be accessible
-    // within the pod via the kubelet, not externally
-    let addr = SocketAddr::from(([127, 0, 0, 1], port));
+    // Bind to all interfaces - Kubernetes probes connect to the pod IP,
+    // not localhost, so we must accept connections on all interfaces.
+    // Network policies should restrict external access if needed.
+    let addr = SocketAddr::from(([0, 0, 0, 0], port));
     let listener = TcpListener::bind(addr).await?;
 
     info!(port = port, "Health check server listening");


### PR DESCRIPTION
## Summary

- Fixes health server binding to 127.0.0.1 instead of 0.0.0.0
- Kubernetes probes connect to the pod IP, not localhost
- The kubelet couldn't reach the health server, causing probe failures

## Problem

The health server was binding to `127.0.0.1`, which only accepts connections from within the same network namespace. Kubernetes probes come from the kubelet on the node, connecting to the pod's IP address:

```
Startup probe failed: dial tcp 10.42.123.234:8081: connect: connection refused
```

After 30 failed probes, Kubernetes would kill the container, causing a restart loop.

## Solution

Bind to `0.0.0.0` instead, allowing connections on all interfaces including the pod's network interface that the kubelet can reach.

## Test plan

- [x] Unit tests pass (721/721)
- [ ] Deploy v0.8.7 to cluster and verify probes succeed
- [ ] Confirm pod shows 1/1 Ready

Fixes #210

🤖 Generated with [Claude Code](https://claude.com/claude-code)