### PR TITLE
fix(ci): add --branch=main for Cloudflare Pages production deploy

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -85,4 +85,4 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_PAGES_ACCOUNT_API }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          command: pages deploy site --project-name=router-hosts-docs
+          command: pages deploy site --project-name=router-hosts-docs --branch=main


### PR DESCRIPTION
## Summary

- Adds `--branch=main` flag to wrangler pages deploy command
- Without this flag, direct-upload deployments are treated as preview deployments
- Fixes deployments not appearing at `router-hosts-docs.pages.dev`

## Problem

Cloudflare Pages direct-upload projects (not git-connected) don't know which "branch" a deployment represents. Without `--branch=main`, each deployment is treated as a **preview deployment**, only accessible via commit-hash subdomain (e.g., `32a7c19c.router-hosts-docs.pages.dev`).

The main domain `router-hosts-docs.pages.dev` was not being updated because no deployments were marked as production.

## Solution

Add `--branch=main` to the wrangler deploy command to indicate this is a production deployment, which will update the main domain.

## Test Plan

- [ ] Merge this PR
- [ ] Trigger docs workflow manually or via next release
- [ ] Verify `router-hosts-docs.pages.dev` serves the latest docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)