### PR TITLE
fix(helm): add watch permission for services in ClusterRole

### DIFF
--- a/charts/router-hosts-operator/templates/clusterrole.yaml
+++ b/charts/router-hosts-operator/templates/clusterrole.yaml
@@ -32,8 +32,8 @@ rules:
   # Note: Secret access is handled by a namespaced Role in the tlsSecretRef.namespace
   # to ensure proper namespace isolation (see role-secret.yaml)
 
-  # Services (for IP resolution)
+  # Services (for IP resolution and Service controller)
   - apiGroups: [""]
     resources: ["services"]
-    verbs: ["get", "list"]
+    verbs: ["get", "list", "watch"]
 {{- end }}


### PR DESCRIPTION
## Summary

The Service controller requires `watch` permission on Services to function. The existing RBAC only had `get`/`list` for IP resolution.

**Error observed:**
```
services is forbidden: User "system:serviceaccount:router-hosts-operator:router-hosts-operator" cannot watch resource "services" in API group "" at the cluster scope
```

## Changes

- Added `watch` verb to Services rule in ClusterRole
- Updated comment to reflect dual purpose (IP resolution + Service controller)

## Test plan

- [ ] Deploy updated Helm chart
- [ ] Verify Service controller no longer shows 403 errors
- [ ] Verify Service resources with annotations are synced

🤖 Generated with [Claude Code](https://claude.com/claude-code)