### PR TITLE
fix(metrics): address PR review findings for OTEL-only metrics

### DIFF
--- a/crates/router-hosts/src/server/config.rs
+++ b/crates/router-hosts/src/server/config.rs
@@ -1395,6 +1395,56 @@ command = ""
         assert_eq!(otel.service_name(), "router-hosts");
         assert!(otel.export_metrics); // default true
         assert!(otel.export_traces); // default true
+        assert_eq!(otel.export_interval_secs, 60); // default 60
         assert!(otel.headers.is_empty());
+    }
+
+    #[test]
+    fn test_otel_config_export_interval_default() {
+        let toml_str = r#"
+            [server]
+            bind_address = "0.0.0.0:50051"
+            hosts_file_path = "/etc/hosts"
+
+            [database]
+            url = "sqlite://:memory:"
+
+            [tls]
+            cert_path = "/cert.pem"
+            key_path = "/key.pem"
+            ca_cert_path = "/ca.pem"
+
+            [metrics.otel]
+            endpoint = "http://localhost:4317"
+        "#;
+
+        let config: Config = toml::from_str(toml_str).unwrap();
+        let otel = config.metrics.unwrap().otel.unwrap();
+        assert_eq!(otel.export_interval_secs, 60); // Verify default
+    }
+
+    #[test]
+    fn test_otel_config_export_interval_custom() {
+        let toml_str = r#"
+            [server]
+            bind_address = "0.0.0.0:50051"
+            hosts_file_path = "/etc/hosts"
+
+            [database]
+            url = "sqlite://:memory:"
+
+            [tls]
+            cert_path = "/cert.pem"
+            key_path = "/key.pem"
+            ca_cert_path = "/ca.pem"
+
+            [metrics.otel]
+            endpoint = "http://localhost:4317"
+            export_interval_secs = 30
+        "#;
+
+        let config: Config = toml::from_str(toml_str).unwrap();
+        let otel = config.metrics.unwrap().otel.unwrap();
+        assert_eq!(otel.export_interval_secs, 30);
     }
 }

--- a/crates/router-hosts/src/server/metrics/mod.rs
+++ b/crates/router-hosts/src/server/metrics/mod.rs
@@ -11,9 +11,10 @@
 //! ```toml
 //! [metrics.otel]
 //! endpoint = "http://otel-collector:4317"
-//! service_name = "router-hosts"  # Optional, defaults to "router-hosts"
-//! export_metrics = true          # Optional, defaults to true
-//! export_traces = true           # Optional, defaults to true
+//! service_name = "router-hosts"       # Optional, defaults to "router-hosts"
+//! export_metrics = true               # Optional, defaults to true
+//! export_traces = true                # Optional, defaults to true
+//! export_interval_secs = 60           # Optional, defaults to 60
 //! ```
 
 pub mod counters;
@@ -31,7 +32,10 @@ pub enum MetricsError {
 
 /// Handle for the metrics subsystem
 ///
-/// Dropping this handle will flush any pending OTEL exports.
+/// Call `shutdown()` to gracefully flush pending OTEL exports before dropping.
+/// If dropped without calling `shutdown()`, the underlying OTEL provider will
+/// attempt to flush on drop, but this may not succeed in all cases (e.g., during
+/// panic unwinds or if the runtime has already shut down).
 pub struct MetricsHandle {
     /// OTEL meter provider for metrics export
     otel_meter_provider: Option<SdkMeterProvider>,

--- a/crates/router-hosts/src/server/mod.rs
+++ b/crates/router-hosts/src/server/mod.rs
@@ -189,7 +189,9 @@ pub async fn run() -> Result<()> {
         .map_err(|e| anyhow::anyhow!("Server error: {}", e));
 
     // Shutdown tracing (flushes pending spans)
-    tracing_handle.shutdown();
+    if let Err(e) = tracing_handle.shutdown() {
+        tracing::warn!(error = %e, "Tracing shutdown failed - some traces may not have been flushed");
+    }
 
     result
 }


### PR DESCRIPTION
## Summary

- Make `TracingHandle.shutdown()` return `Result<>` for consistency with `MetricsHandle.shutdown()`
- Add `export_interval_secs` validation: reject 0, warn on <10s or >3600s
- Document deferred OTEL connection behavior in log message
- Improve recorder conflict error message with actionable guidance
- Fix inaccurate `MetricsHandle` docstring about Drop flushing
- Add `export_interval_secs` to module TOML example
- Clarify recorder comment about provider dependency
- Add tests for `export_interval_secs` default/custom values

## Test plan

- [x] All metrics/config tests pass (106 tests)
- [x] Lint passes
- [x] New test `test_export_interval_zero_rejected` validates error case

Follow-up to #238

🤖 Generated with [Claude Code](https://claude.com/claude-code)