### PR TITLE
fix(operator): repair chart image ref broken by digest auto-pin

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -16,6 +16,12 @@
   },
   "packageRules": [
     {
+      "description": "The operator chart's own image is versioned in-repo by release-please (charts/router-hosts-operator/Chart.yaml appVersion, consumed via image.tag default). Renovate must not pin or bump it.",
+      "matchManagers": ["helm-values"],
+      "matchPackageNames": ["ghcr.io/fzymgc-house/router-hosts"],
+      "enabled": false
+    },
+    {
       "description": "Auto-merge non-major updates once the release is at least 24h old",
       "matchUpdateTypes": ["minor", "patch", "digest", "pin", "lockFileMaintenance"],
       "minimumReleaseAge": "24 hours",

--- a/charts/router-hosts-operator/templates/_helpers.tpl
+++ b/charts/router-hosts-operator/templates/_helpers.tpl
@@ -60,9 +60,14 @@ Create the name of the service account to use
 {{- end }}
 
 {{/*
-Image reference
+Image reference. A digest pin (image.digest) takes precedence and is rendered
+as repository@digest; otherwise repository:tag, with tag defaulting to the
+chart appVersion.
 */}}
 {{- define "router-hosts-operator.image" -}}
-{{- $tag := .Values.image.tag | default .Chart.AppVersion }}
-{{- printf "%s:%s" .Values.image.repository $tag }}
+{{- if .Values.image.digest }}
+{{- printf "%s@%s" .Values.image.repository .Values.image.digest }}
+{{- else }}
+{{- printf "%s:%s" .Values.image.repository (.Values.image.tag | default .Chart.AppVersion) }}
+{{- end }}
 {{- end }}

--- a/charts/router-hosts-operator/values.yaml
+++ b/charts/router-hosts-operator/values.yaml
@@ -6,8 +6,12 @@
 # entrypoint to run the operator.
 image:
   repository: ghcr.io/fzymgc-house/router-hosts
-  # Overrides the image tag whose default is the chart appVersion
-  tag: "@sha256:d9aa2ed57926ac5635919c63deec7cd7778d49953732d7ea7f2476c26dd3500f"
+  # Tag to pull; defaults to the chart appVersion (kept in lockstep with each
+  # release by release-please), so leaving it empty tracks every release.
+  tag: ""
+  # Optional immutable digest pin (e.g. "sha256:abc123..."). When set, the
+  # image is referenced as repository@digest and takes precedence over tag.
+  digest: ""
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []


### PR DESCRIPTION
## Problem

Renovate (`config:best-practices` → `docker:pinDigests`) auto-pinned the operator chart image against an **empty base tag** in #297, and the auto-merge rule (which includes `pin`/`digest` update types) merged it. Combined with the #296 image-repo rename, main's chart now renders an **invalid image reference**:

```
# values.yaml on main
tag: "@sha256:d9aa2ed..."
# helper renders:
image: ghcr.io/fzymgc-house/router-hosts:@sha256:d9aa2ed...   # invalid → ImagePullBackOff
```

Two defects: the `:@sha256:` form is malformed, and the digest (`d9aa2ed…`, resolved against the old `router-hosts-operator` repo) matches no current image (`router-hosts:0.10.0`/`latest` = `sha256:5fb24e9b…`).

## Fix

The chart image is **versioned in-repo by release-please** (`Chart.yaml` `appVersion`, already auto-bumped to `0.10.0`), consumed via the `image.tag` default — so it tracks every release with no manual step, and Renovate should not manage it.

- **`values.yaml`** — restore `tag: ""` (defaults to `appVersion`); add an optional `image.digest` field for explicit immutable pinning.
- **`_helpers.tpl`** — digest-aware image helper: `repository@digest` when `image.digest` is set, else `repository:tag` (tag → `appVersion`).
- **`renovate.json`** — `packageRule` disabling the `helm-values` manager for `ghcr.io/fzymgc-house/router-hosts`, so Renovate cannot re-pin/re-break the self-managed image.

## Verification

- `helm template` renders `image: ghcr.io/fzymgc-house/router-hosts:0.10.0` (tracks `appVersion`); `--set image.digest=sha256:5fb24e9b…` renders `…/router-hosts@sha256:5fb24e9b…` (valid digest pin).
- `helm lint` passes; `renovate.json` is valid JSON.
- Confirmed the fix replaces main's broken `tag: "@sha256:d9aa…"` with `tag: ""`.

Refs #296, #297.

🤖 Generated with [Claude Code](https://claude.com/claude-code)