### PR TITLE
fix(docs): repair dangling proto-doc anchor & gate docs build on PRs (#314)

### DIFF
--- a/.github/workflows/ci-go.yml
+++ b/.github/workflows/ci-go.yml
@@ -105,10 +105,38 @@ jobs:
         run: go install github.com/go-task/task/v3/cmd/task@latest
       - name: Verify CRDs and deepcopy match Go types
         run: task manifests:verify
+  docs:
+    name: Docs build (strict)
+    runs-on: namespace-profile-linux-amd64-2x4
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+        with:
+          go-version-file: go.mod
+          cache: false
+      - name: Cache Go modules and build
+        uses: namespacelabs/nscloud-cache-action@15799a6b54e5765f85b2aac25b3f0df43ed571c0 # v1
+        with:
+          cache: go
+      - name: Install task runner
+        run: go install github.com/go-task/task/v3/cmd/task@latest
+      - name: Install protoc
+        uses: arduino/setup-protoc@v3
+        with:
+          version: "25.x"
+      - name: Install protoc-gen-doc
+        run: go install github.com/pseudomuto/protoc-gen-doc/cmd/protoc-gen-doc@v1.5.1
+      - name: Install uv
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
+      - name: Build router-hosts binary (for CLI docs)
+        run: go build -o /tmp/router-hosts ./cmd/router-hosts
+      - name: Build docs (strict)
+        run: task docs:ci BINARY=/tmp/router-hosts
   ci-go-complete:
     name: CI (Go) Complete
     if: always()
-    needs: [lint, vuln, test, build, buf-check, manifests]
+    needs: [lint, vuln, test, build, buf-check, manifests, docs]
     runs-on: namespace-profile-linux-amd64-2x4
     timeout-minutes: 5
     steps:
@@ -120,13 +148,15 @@ jobs:
           BUILD_RESULT: ${{ needs.build.result }}
           BUF_RESULT: ${{ needs.buf-check.result }}
           MANIFESTS_RESULT: ${{ needs.manifests.result }}
+          DOCS_RESULT: ${{ needs.docs.result }}
         run: |
           if [[ "$LINT_RESULT" != "success" ]] ||
              [[ "$VULN_RESULT" != "success" ]] ||
              [[ "$TEST_RESULT" != "success" ]] ||
              [[ "$BUILD_RESULT" != "success" ]] ||
              [[ "$BUF_RESULT" != "success" ]] ||
-             [[ "$MANIFESTS_RESULT" != "success" ]]; then
+             [[ "$MANIFESTS_RESULT" != "success" ]] ||
+             [[ "$DOCS_RESULT" != "success" ]]; then
             echo "One or more CI jobs failed"
             exit 1
           fi

--- a/scripts/generate-proto-docs.sh
+++ b/scripts/generate-proto-docs.sh
@@ -70,6 +70,13 @@ HEADER
 cat "$OUTPUT_FILE" >> "$TEMP_FILE"
 mv "$TEMP_FILE" "$OUTPUT_FILE"
 
+# protoc-gen-doc cross-links well-known types (e.g. google.protobuf.Timestamp)
+# to in-page anchors like #google-protobuf-Timestamp, but never renders a
+# section for them — they are imported, not defined in our proto. The dangling
+# anchors fail `mkdocs build --strict`. Redirect them to the official protobuf
+# reference so the links stay useful instead of broken.
+perl -pi -e 's{\(#google-protobuf-(\w+)\)}{"(https://protobuf.dev/reference/protobuf/google.protobuf/#".lc($1).")"}ge' "$OUTPUT_FILE"
+
 # Verify output has content
 line_count=$(wc -l < "$OUTPUT_FILE" | tr -d ' ')
 if [[ "$line_count" -lt 20 ]]; then


### PR DESCRIPTION
## Summary

Fixes #314. `mkdocs build --strict` fails on `main`: the generated `docs/reference/api.md` links `#google-protobuf-Timestamp`, which has no section (`protoc-gen-doc` cross-links well-known types but never renders them — they're imported, not defined in our proto). `docs.yml` only runs **after Release**, so this breaks the docs deploy with no PR-time gate.

## Changes

- **`scripts/generate-proto-docs.sh`** — post-process the generated markdown to redirect well-known-type anchors (`#google-protobuf-*`) to the official protobuf reference (`https://protobuf.dev/reference/protobuf/google.protobuf/#<type>`), keeping the links useful instead of broken. Portable (`/usr/bin/perl`, no GNU-only sed).
- **`.github/workflows/ci-go.yml`** — add a `Docs build (strict)` job running `task docs:ci` (CLI + proto doc generation + `mkdocs build --strict`) on every PR, gated in `ci-go-complete`.

The diff is intentionally minimal: the generated `api.md`/`cli.md` are build artifacts (committed only as stubs, regenerated at build), so only the generator script and the workflow change.

## Verification

- Reproduced the failure locally; after the fix the 4 `Timestamp` links resolve to `protobuf.dev` and the anchor warning is gone.
- The only residual local strict warning is the `git-revision-date` plugin reporting "no git directory" — an artifact of building inside a jj workspace (no `.git`); CI checks out real git, so it won't occur. The new CI job is the authoritative check.

## Context

Third instance of the same root-cause pattern this session — **no PR gate → drift caught only at release**: CRD/binary drift (#308 → #309, added `manifests:verify`), operator-docs rot (#310 → #311), and now docs-build (#314). Each fix adds the missing PR-time gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)