### PR TITLE
fix(server): regenerate outputs on startup

### DIFF
--- a/internal/client/commands/serve.go
+++ b/internal/client/commands/serve.go
@@ -157,5 +157,11 @@ func runServe(ctx context.Context, configPath string) error {
 		"dnsmasq_conf", cfg.Server.DnsmasqConfPath,
 	)
 
+	// Materialize outputs from the persisted DB on startup so a fresh deploy or
+	// restart writes hosts_file_path and dnsmasq_conf_path even when no host has
+	// changed since the last write (GH #327).
+	logger.Info("regenerating outputs on startup")
+	svc.RegenerateOutputs(ctx)
+
 	return srv.Run(ctx)
 }

--- a/internal/server/service.go
+++ b/internal/server/service.go
@@ -92,6 +92,16 @@ func NewHostsServiceImpl(handler *CommandHandler, store storage.Storage, opts ..
 	return svc
 }
 
+// RegenerateOutputs writes all configured output files (hosts file and/or
+// dnsmasq conf) from current store state, independent of any host mutation.
+// The server calls this once on startup so a fresh deploy or restart
+// materializes outputs from the persisted database even when no host has
+// changed since the last write (GH #327). Idempotent; errors are logged, not
+// returned.
+func (s *HostsServiceImpl) RegenerateOutputs(ctx context.Context) {
+	s.regenerateOutputs(ctx, "startup")
+}
+
 // regenerateOutputs regenerates every configured output file (hosts file and/or
 // dnsmasq conf) from current store state. Regeneration errors are logged rather
 // than returned: the mutation has already been committed, so a failed file

--- a/internal/server/service_test.go
+++ b/internal/server/service_test.go
@@ -1927,3 +1927,50 @@ func TestService_RegeneratesBothOutputs(t *testing.T) {
 	require.NoError(t, err)
 	assert.Contains(t, string(confData), "local=/server.local/\naddress=/server.local/192.168.1.10")
 }
+
+// TestService_RegenerateOutputs_MaterializesWithoutMutation is the regression
+// test for GH #327: a fresh server start must write outputs from the persisted
+// DB even when no host has changed since the last write. It populates the store
+// first (simulating a prior process's data), then builds a new service with
+// fresh output paths (simulating a restart) and calls RegenerateOutputs without
+// any mutation RPC.
+func TestService_RegenerateOutputs_MaterializesWithoutMutation(t *testing.T) {
+	ctx := context.Background()
+
+	store, err := sqlite.New("file::memory:?mode=memory&cache=shared", slog.Default())
+	require.NoError(t, err)
+	require.NoError(t, store.Initialize(ctx))
+	t.Cleanup(func() { _ = store.Close() })
+
+	// Persisted data from a prior process — added directly to the store, not
+	// via the service under test, so no regeneration has occurred.
+	handler := NewCommandHandler(store)
+	_, err = handler.AddHost(ctx, "192.168.20.145", "auth.fzymgc.house", nil, nil, []string{"sso.fzymgc.house"})
+	require.NoError(t, err)
+
+	dir := t.TempDir()
+	hostsPath := filepath.Join(dir, "hosts")
+	confPath := filepath.Join(dir, "router-hosts.conf")
+
+	// Fresh service + generators, as on a restart. The output files do not
+	// exist yet.
+	require.NoFileExists(t, hostsPath)
+	require.NoFileExists(t, confPath)
+
+	svc := NewHostsServiceImpl(handler, store,
+		WithHostsGenerator(NewHostsFileGenerator(hostsPath)),
+		WithDnsmasqGenerator(NewDnsmasqConfGenerator(confPath)),
+	)
+
+	// Startup regeneration — no AddHost/UpdateHost/DeleteHost involved.
+	svc.RegenerateOutputs(ctx)
+
+	hostsData, err := os.ReadFile(hostsPath)
+	require.NoError(t, err)
+	assert.Contains(t, string(hostsData), "192.168.20.145\tauth.fzymgc.house")
+
+	confData, err := os.ReadFile(confPath)
+	require.NoError(t, err)
+	assert.Contains(t, string(confData), "local=/auth.fzymgc.house/\naddress=/auth.fzymgc.house/192.168.20.145")
+	assert.Contains(t, string(confData), "local=/sso.fzymgc.house/\naddress=/sso.fzymgc.house/192.168.20.145")
+}


### PR DESCRIPTION
## Summary

Fixes #327. On a fresh deploy/restart with `dnsmasq_conf_path` (and/or `hosts_file_path`) configured, the server never wrote the output files unless a host record changed — leaving the dnsmasq `local=`/`address=` records (the #325/#326 AAAA-leak suppression) **unwritten** until the next add/update/delete, and leaving the hosts file stale.

## Root cause

`regenerateOutputs` is the only code that writes outputs, and it is invoked exclusively from the 5 mutation RPCs (`AddHost`, `UpdateHost`, `DeleteHost`, `ImportHosts`, `RollbackToSnapshot`). `runServe` wires the generators into the service but never triggers an initial write, so a process start with no subsequent data change leaves outputs unmaterialized. This explains every reported symptom: dnsmasq conf absent (never written), hosts file stale mtime (written by a prior process), and silent startup logs (no regen ran).

## Fix

Regenerate both outputs from the persisted DB once on startup (issue's preferred option 1 — idempotent, deploy-friendly, no operator action):

- **`internal/server/service.go`**: new exported `RegenerateOutputs(ctx)` wrapping the existing `regenerateOutputs(ctx, "startup")` — single source of truth, reused by the startup path.
- **`internal/client/commands/serve.go`**: after store init + service creation, log `regenerating outputs on startup` and call `svc.RegenerateOutputs(ctx)` before serving. Non-fatal (errors logged with `op=startup`), consistent with the existing post-mutation behavior.

A restart now always materializes the current `hosts_file_path` + `dnsmasq_conf_path` (also fixing the stale-hosts-file mtime).

## Testing

- **Regression test** `TestService_RegenerateOutputs_MaterializesWithoutMutation`: populates the store, builds a fresh service with new output paths (simulating a restart), asserts both files are written by `RegenerateOutputs` with **no mutation RPC**. Fails before the fix (method absent), passes after.
- `golangci-lint run ./...` → 0 issues
- `go test ./internal/server/...` (race) → pass; touched packages green (server 87.6%).
- Note: `internal/acme/TestNewManager_BuildObtainFunc_BadEnvVar` fails in my local sandbox only — it makes a real network call to LetsEncrypt staging that the sandbox blocks (`connect: bad file descriptor`); unrelated to this change (no `internal/acme` files touched) and green in CI.

## Notes

Did not implement the issue's alternative option 2 (a `regenerate` admin RPC/CLI) — option 1 fully resolves the reported deploy gap. Happy to add option 2 as a follow-up if operators still want a manual force-write.

Fixes #327

🤖 Generated with [Claude Code](https://claude.com/claude-code)