### PR TITLE
fix: remediate aggregate-bloat runaway (commit-on-timeout, snapshot schema, idempotent reconcile)

### DIFF
--- a/internal/operator/grpc_hostclient.go
+++ b/internal/operator/grpc_hostclient.go
@@ -2,12 +2,22 @@ package operator
 
 import (
 	"context"
+	"errors"
+	"io"
 
 	hostsv1 "github.com/fzymgc-house/router-hosts/api/v1/router_hosts/v1"
 	"github.com/fzymgc-house/router-hosts/internal/client"
 	"github.com/fzymgc-house/router-hosts/internal/config"
 	"github.com/samber/oops"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
+
+// ErrHostAlreadyExists is a sentinel returned by AddHost when the server
+// reports that a host with the same IP and hostname already exists
+// (gRPC AlreadyExists). Callers use errors.Is to detect this case and
+// adopt the existing entry rather than retrying the create indefinitely.
+var ErrHostAlreadyExists = errors.New("host already exists")
 
 // grpcHostClient adapts the project's gRPC client to the HostClient interface.
 type grpcHostClient struct {
@@ -36,6 +46,8 @@ func (g *grpcHostClient) Close() error {
 }
 
 // AddHost implements HostClient.
+// Returns an error wrapping ErrHostAlreadyExists when the server responds with
+// gRPC AlreadyExists; all other errors are wrapped with oops context.
 func (g *grpcHostClient) AddHost(ctx context.Context, ip, hostname, comment string, aliases, tags []string) (string, error) {
 	var commentPtr *string
 	if comment != "" {
@@ -50,9 +62,50 @@ func (g *grpcHostClient) AddHost(ctx context.Context, ip, hostname, comment stri
 		Tags:      tags,
 	})
 	if err != nil {
+		if status.Code(err) == codes.AlreadyExists {
+			return "", oops.Wrapf(ErrHostAlreadyExists, "adding host %s/%s", ip, hostname)
+		}
 		return "", oops.Wrapf(err, "adding host %s/%s", ip, hostname)
 	}
 	return resp.GetId(), nil
+}
+
+// FindHost implements HostClient by querying SearchHosts and exact-matching
+// on both IP and hostname. Returns nil, nil when no matching entry exists.
+func (g *grpcHostClient) FindHost(ctx context.Context, ip, hostname string) (*HostEntry, error) {
+	// Cancel the server stream promptly on early return (exact match found)
+	// so the server stops sending remaining results.
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	stream, err := g.c.Hosts.SearchHosts(ctx, &hostsv1.SearchHostsRequest{Query: hostname})
+	if err != nil {
+		return nil, oops.Wrapf(err, "searching for host %s/%s", ip, hostname)
+	}
+	for {
+		resp, err := stream.Recv()
+		if errors.Is(err, io.EOF) {
+			return nil, nil
+		}
+		if err != nil {
+			return nil, oops.Wrapf(err, "receiving search results for host %s/%s", ip, hostname)
+		}
+		entry := resp.GetEntry()
+		if entry == nil {
+			continue
+		}
+		// SearchHosts performs contains/prefix matching — exact-match both
+		// fields client-side to avoid adopting the wrong host.
+		if entry.GetIpAddress() == ip && entry.GetHostname() == hostname {
+			return &HostEntry{
+				ID:       entry.GetId(),
+				IP:       entry.GetIpAddress(),
+				Hostname: entry.GetHostname(),
+				Aliases:  entry.GetAliases(),
+				Tags:     entry.GetTags(),
+				Version:  entry.GetVersion(),
+			}, nil
+		}
+	}
 }
 
 // UpdateHost implements HostClient.

--- a/internal/operator/grpc_hostclient_test.go
+++ b/internal/operator/grpc_hostclient_test.go
@@ -2,6 +2,7 @@ package operator
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 	"net"
 	"testing"
@@ -11,7 +12,6 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials/insecure"
-	"google.golang.org/grpc/status"
 	"google.golang.org/grpc/test/bufconn"
 
 	hostsv1 "github.com/fzymgc-house/router-hosts/api/v1/router_hosts/v1"
@@ -199,12 +199,34 @@ func TestGRPCHostClient_AddHost_Duplicate(t *testing.T) {
 	_, err = gc.AddHost(ctx, "192.168.1.1", "dup.local", "", nil, nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "adding host")
+	// The sentinel must be detectable so reconcileCreate can adopt without hot-looping.
+	assert.True(t, errors.Is(err, ErrHostAlreadyExists), "must wrap ErrHostAlreadyExists for reconciler adoption")
+}
 
-	// Verify it wraps a gRPC AlreadyExists error
-	st, ok := status.FromError(err)
-	// oops wraps the error so the gRPC status may not be directly extractable
-	_ = ok
-	_ = st
+func TestGRPCHostClient_FindHost(t *testing.T) {
+	gc, cleanup := newBufconnEnv(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	// Add two hosts: exact target and a hostname-prefix collision with a different IP.
+	_, err := gc.AddHost(ctx, "10.0.0.1", "find.local", "", nil, nil)
+	require.NoError(t, err)
+	_, err = gc.AddHost(ctx, "10.0.0.99", "find.local", "", nil, nil) // same hostname, different IP
+	require.NoError(t, err)
+
+	// FindHost must return the entry with the exact IP.
+	found, err := gc.FindHost(ctx, "10.0.0.1", "find.local")
+	require.NoError(t, err)
+	require.NotNil(t, found, "should find the exact match")
+	assert.Equal(t, "10.0.0.1", found.IP)
+	assert.Equal(t, "find.local", found.Hostname)
+	assert.NotEmpty(t, found.ID)
+	assert.NotEmpty(t, found.Version)
+
+	// Non-existent combination returns nil, nil.
+	notFound, err := gc.FindHost(ctx, "10.0.0.1", "no-such-host.local")
+	require.NoError(t, err)
+	assert.Nil(t, notFound, "non-existent host must return nil")
 }
 
 func TestNewGRPCHostClient_InvalidAddress(t *testing.T) {

--- a/internal/operator/hostclient.go
+++ b/internal/operator/hostclient.go
@@ -18,6 +18,8 @@ type HostEntry struct {
 // a mock.
 type HostClient interface {
 	// AddHost creates a new host entry and returns the server-assigned ID.
+	// Returns an error wrapping ErrHostAlreadyExists when the server reports
+	// that a host with the same IP and hostname already exists.
 	AddHost(ctx context.Context, ip, hostname, comment string, aliases, tags []string) (string, error)
 
 	// UpdateHost modifies an existing host entry identified by id.
@@ -30,6 +32,10 @@ type HostClient interface {
 
 	// GetHost retrieves a single host entry by ID.
 	GetHost(ctx context.Context, id string) (*HostEntry, error)
+
+	// FindHost searches for a host entry with an exact match on both IP and
+	// hostname. Returns nil, nil if no matching entry exists.
+	FindHost(ctx context.Context, ip, hostname string) (*HostEntry, error)
 
 	// Close releases any resources held by the client.
 	Close() error

--- a/internal/operator/hostmapping_controller.go
+++ b/internal/operator/hostmapping_controller.go
@@ -2,6 +2,7 @@ package operator
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"time"
@@ -72,12 +73,17 @@ func (r *HostMappingReconciler) reconcileUpsert(ctx context.Context, log *slog.L
 }
 
 // reconcileCreate creates a new host entry on the router-hosts server.
+// When the server returns AlreadyExists, it delegates to adoptExistingHost
+// to find and adopt the pre-existing entry, breaking the hot-loop.
 func (r *HostMappingReconciler) reconcileCreate(ctx context.Context, log *slog.Logger, hm *operatorv1alpha1.HostMapping) (ctrl.Result, error) {
 	log.Info("creating host entry")
 
 	comment := fmt.Sprintf("k8s:%s/%s", hm.Namespace, hm.Name)
 	id, err := r.HostClient.AddHost(ctx, hm.Spec.IP, hm.Spec.Hostname, comment, hm.Spec.Aliases, hm.Spec.Tags)
 	if err != nil {
+		if errors.Is(err, ErrHostAlreadyExists) {
+			return r.adoptExistingHost(ctx, log, hm)
+		}
 		log.Error("failed to create host entry", "error", err)
 		r.setStatus(hm, operatorv1alpha1.HostMappingPhaseError, err.Error(), "")
 		r.setSyncedCondition(hm, metav1.ConditionFalse, "CreateFailed", err.Error())
@@ -108,6 +114,45 @@ func (r *HostMappingReconciler) reconcileCreate(ctx context.Context, log *slog.L
 
 	log.Info("host entry created", "hostId", id)
 	return ctrl.Result{}, nil
+}
+
+// adoptExistingHost handles the AlreadyExists case: it looks up the existing
+// host entry by exact IP+hostname, records the ID and version on the status,
+// then delegates to reconcileUpdate so the entry converges to the desired spec
+// in the same reconcile pass. If the lookup fails or finds nothing (e.g. a
+// race where the host was deleted between AddHost and FindHost), it falls back
+// to the standard error/requeue path.
+func (r *HostMappingReconciler) adoptExistingHost(ctx context.Context, log *slog.Logger, hm *operatorv1alpha1.HostMapping) (ctrl.Result, error) {
+	log.Info("host already exists, attempting adoption", "ip", hm.Spec.IP, "hostname", hm.Spec.Hostname)
+
+	existing, err := r.HostClient.FindHost(ctx, hm.Spec.IP, hm.Spec.Hostname)
+	if err != nil {
+		log.Error("failed to find existing host for adoption", "error", err)
+		r.setStatus(hm, operatorv1alpha1.HostMappingPhaseError, err.Error(), "")
+		r.setSyncedCondition(hm, metav1.ConditionFalse, "AdoptionFailed", err.Error())
+		if statusErr := r.Status().Update(ctx, hm); statusErr != nil {
+			log.Error("failed to update status", "error", statusErr)
+		}
+		return ctrl.Result{RequeueAfter: requeueDelayLong}, nil
+	}
+	if existing == nil {
+		// Race: deleted between AddHost and FindHost — requeue to try again.
+		msg := "host entry not found during adoption (possible race); will retry"
+		log.Warn(msg, "ip", hm.Spec.IP, "hostname", hm.Spec.Hostname)
+		r.setStatus(hm, operatorv1alpha1.HostMappingPhaseError, msg, "")
+		r.setSyncedCondition(hm, metav1.ConditionFalse, "AdoptionFailed", msg)
+		if statusErr := r.Status().Update(ctx, hm); statusErr != nil {
+			log.Error("failed to update status", "error", statusErr)
+		}
+		return ctrl.Result{RequeueAfter: requeueDelayLong}, nil
+	}
+
+	log.Info("adopting existing host entry", "existingID", existing.ID, "ip", hm.Spec.IP, "hostname", hm.Spec.Hostname)
+	hm.Status.HostID = existing.ID
+	hm.Status.HostVersion = existing.Version
+
+	// Delegate to reconcileUpdate to converge the entry to the desired spec.
+	return r.reconcileUpdate(ctx, log, hm)
 }
 
 // reconcileUpdate updates the host entry when the spec has changed.

--- a/internal/operator/hostmapping_controller_test.go
+++ b/internal/operator/hostmapping_controller_test.go
@@ -25,6 +25,7 @@ type mockHostClient struct {
 	updateHostFn func(ctx context.Context, id, ip, hostname, comment string, aliases, tags []string, version string) error
 	deleteHostFn func(ctx context.Context, id string) error
 	getHostFn    func(ctx context.Context, id string) (*HostEntry, error)
+	findHostFn   func(ctx context.Context, ip, hostname string) (*HostEntry, error)
 }
 
 func (m *mockHostClient) AddHost(ctx context.Context, ip, hostname, comment string, aliases, tags []string) (string, error) {
@@ -58,6 +59,13 @@ func (m *mockHostClient) GetHost(ctx context.Context, id string) (*HostEntry, er
 		Hostname: "test.local",
 		Version:  "v1",
 	}, nil
+}
+
+func (m *mockHostClient) FindHost(ctx context.Context, ip, hostname string) (*HostEntry, error) {
+	if m.findHostFn != nil {
+		return m.findHostFn(ctx, ip, hostname)
+	}
+	return nil, nil
 }
 
 func (m *mockHostClient) Close() error { return nil }
@@ -580,4 +588,245 @@ func TestReconcile_DeleteFailure_Requeues(t *testing.T) {
 	var updated operatorv1alpha1.HostMapping
 	require.NoError(t, k8sClient.Get(context.Background(), types.NamespacedName{Name: "my-host", Namespace: "default"}, &updated))
 	assert.Contains(t, updated.Finalizers, hostCleanupFinalizer)
+}
+
+// ---------------------------------------------------------------------------
+// AlreadyExists / adoption tests (GH #313)
+// ---------------------------------------------------------------------------
+
+// TestReconcile_AlreadyExists_AdoptsExistingHost verifies that when AddHost
+// returns ErrHostAlreadyExists the reconciler adopts the existing entry via
+// FindHost and converges state, instead of hot-looping with repeated errors.
+func TestReconcile_AlreadyExists_AdoptsExistingHost(t *testing.T) {
+	s := testScheme(t)
+	hm := newTestHostMapping("my-host", "default", "192.168.1.10", "my-host.local")
+	hm.Finalizers = []string{hostCleanupFinalizer}
+
+	k8sClient := fake.NewClientBuilder().
+		WithScheme(s).
+		WithObjects(hm).
+		WithStatusSubresource(hm).
+		Build()
+
+	addCalls := 0
+	updateCalled := false
+	mock := &mockHostClient{
+		addHostFn: func(_ context.Context, _, _, _ string, _, _ []string) (string, error) {
+			addCalls++
+			return "", fmt.Errorf("adding host 192.168.1.10/my-host.local: %w", ErrHostAlreadyExists)
+		},
+		findHostFn: func(_ context.Context, ip, hostname string) (*HostEntry, error) {
+			assert.Equal(t, "192.168.1.10", ip)
+			assert.Equal(t, "my-host.local", hostname)
+			return &HostEntry{
+				ID:       "existing-id-42",
+				IP:       ip,
+				Hostname: hostname,
+				Version:  "v3",
+			}, nil
+		},
+		updateHostFn: func(_ context.Context, id, _, _, _ string, _, _ []string, version string) error {
+			updateCalled = true
+			assert.Equal(t, "existing-id-42", id)
+			assert.Equal(t, "v3", version)
+			return nil
+		},
+		getHostFn: func(_ context.Context, id string) (*HostEntry, error) {
+			return &HostEntry{ID: id, Version: "v4"}, nil
+		},
+	}
+
+	r := &HostMappingReconciler{
+		Client:     k8sClient,
+		Scheme:     s,
+		HostClient: mock,
+		Log:        slog.Default(),
+	}
+
+	result, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "my-host", Namespace: "default"},
+	})
+	require.NoError(t, err)
+	// Must not request the long error-requeue (no hot-loop).
+	assert.Equal(t, ctrl.Result{}, result, "adoption should succeed without requeue")
+	assert.Equal(t, 1, addCalls, "AddHost called exactly once")
+	assert.True(t, updateCalled, "reconcileUpdate must run to converge spec")
+
+	// Verify status: HostID adopted, Synced=True, no error phase.
+	var updated operatorv1alpha1.HostMapping
+	require.NoError(t, k8sClient.Get(context.Background(), types.NamespacedName{Name: "my-host", Namespace: "default"}, &updated))
+	assert.Equal(t, "existing-id-42", updated.Status.HostID)
+	assert.Equal(t, "v4", updated.Status.HostVersion, "version refreshed by GetHost after UpdateHost")
+	assert.Equal(t, operatorv1alpha1.HostMappingPhaseSynced, updated.Status.Phase)
+
+	require.Len(t, updated.Status.Conditions, 1)
+	assert.Equal(t, operatorv1alpha1.ConditionSynced, updated.Status.Conditions[0].Type)
+	assert.Equal(t, metav1.ConditionTrue, updated.Status.Conditions[0].Status)
+}
+
+// TestReconcile_AlreadyExists_Idempotent verifies that after adoption the next
+// Reconcile goes through reconcileUpdate (not another AddHost call).
+func TestReconcile_AlreadyExists_Idempotent(t *testing.T) {
+	s := testScheme(t)
+	hm := newTestHostMapping("my-host", "default", "192.168.1.10", "my-host.local")
+	hm.Finalizers = []string{hostCleanupFinalizer}
+
+	k8sClient := fake.NewClientBuilder().
+		WithScheme(s).
+		WithObjects(hm).
+		WithStatusSubresource(hm).
+		Build()
+
+	addCalls := 0
+	updateCalls := 0
+	mock := &mockHostClient{
+		addHostFn: func(_ context.Context, _, _, _ string, _, _ []string) (string, error) {
+			addCalls++
+			return "", fmt.Errorf("adding host: %w", ErrHostAlreadyExists)
+		},
+		findHostFn: func(_ context.Context, ip, hostname string) (*HostEntry, error) {
+			return &HostEntry{ID: "existing-id-42", IP: ip, Hostname: hostname, Version: "v1"}, nil
+		},
+		updateHostFn: func(_ context.Context, _ string, _, _, _ string, _, _ []string, _ string) error {
+			updateCalls++
+			return nil
+		},
+		getHostFn: func(_ context.Context, id string) (*HostEntry, error) {
+			return &HostEntry{ID: id, Version: "v2"}, nil
+		},
+	}
+
+	r := &HostMappingReconciler{
+		Client:     k8sClient,
+		Scheme:     s,
+		HostClient: mock,
+		Log:        slog.Default(),
+	}
+
+	// First reconcile: AlreadyExists → adoption → reconcileUpdate.
+	result, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "my-host", Namespace: "default"},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, ctrl.Result{}, result)
+	assert.Equal(t, 1, addCalls)
+	assert.Equal(t, 1, updateCalls)
+
+	// Second reconcile: HostID is now set, so reconcileUpdate runs directly.
+	result, err = r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "my-host", Namespace: "default"},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, ctrl.Result{}, result)
+	assert.Equal(t, 1, addCalls, "AddHost must NOT be called again")
+	assert.Equal(t, 2, updateCalls)
+}
+
+// TestReconcile_FindHost_ExactMatch verifies that FindHost performs exact
+// IP+hostname matching — a candidate that shares a hostname prefix but has a
+// different IP must not be adopted.
+func TestReconcile_FindHost_ExactMatch(t *testing.T) {
+	s := testScheme(t)
+	hm := newTestHostMapping("my-host", "default", "10.0.0.1", "host.local")
+	hm.Finalizers = []string{hostCleanupFinalizer}
+
+	k8sClient := fake.NewClientBuilder().
+		WithScheme(s).
+		WithObjects(hm).
+		WithStatusSubresource(hm).
+		Build()
+
+	mock := &mockHostClient{
+		addHostFn: func(_ context.Context, _, _, _ string, _, _ []string) (string, error) {
+			return "", fmt.Errorf("adding host: %w", ErrHostAlreadyExists)
+		},
+		findHostFn: func(_ context.Context, ip, hostname string) (*HostEntry, error) {
+			// Simulate the server returning a prefix-collision candidate first,
+			// then the actual match. FindHost must return the exact match only.
+			candidates := []*HostEntry{
+				{ID: "wrong-id", IP: "10.0.0.99", Hostname: "host.local"},    // wrong IP
+				{ID: "right-id", IP: "10.0.0.1", Hostname: "host.local"},     // exact match
+				{ID: "also-wrong", IP: "10.0.0.1", Hostname: "host.local.x"}, // wrong hostname
+			}
+			for _, c := range candidates {
+				if c.IP == ip && c.Hostname == hostname {
+					c.Version = "v1"
+					return c, nil
+				}
+			}
+			return nil, nil
+		},
+		updateHostFn: func(_ context.Context, id, _, _, _ string, _, _ []string, _ string) error {
+			assert.Equal(t, "right-id", id, "must adopt exact match, not prefix collision")
+			return nil
+		},
+		getHostFn: func(_ context.Context, id string) (*HostEntry, error) {
+			return &HostEntry{ID: id, Version: "v2"}, nil
+		},
+	}
+
+	r := &HostMappingReconciler{
+		Client:     k8sClient,
+		Scheme:     s,
+		HostClient: mock,
+		Log:        slog.Default(),
+	}
+
+	result, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "my-host", Namespace: "default"},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, ctrl.Result{}, result)
+
+	var updated operatorv1alpha1.HostMapping
+	require.NoError(t, k8sClient.Get(context.Background(), types.NamespacedName{Name: "my-host", Namespace: "default"}, &updated))
+	assert.Equal(t, "right-id", updated.Status.HostID)
+	assert.Equal(t, operatorv1alpha1.HostMappingPhaseSynced, updated.Status.Phase)
+}
+
+// TestReconcile_AlreadyExists_FindHostReturnsNil_Fallback verifies that when
+// FindHost finds nothing after AlreadyExists (race: host deleted between calls)
+// the reconciler falls back to error/requeue without panicking or adopting a
+// wrong ID.
+func TestReconcile_AlreadyExists_FindHostReturnsNil_Fallback(t *testing.T) {
+	s := testScheme(t)
+	hm := newTestHostMapping("my-host", "default", "192.168.1.10", "my-host.local")
+	hm.Finalizers = []string{hostCleanupFinalizer}
+
+	k8sClient := fake.NewClientBuilder().
+		WithScheme(s).
+		WithObjects(hm).
+		WithStatusSubresource(hm).
+		Build()
+
+	mock := &mockHostClient{
+		addHostFn: func(_ context.Context, _, _, _ string, _, _ []string) (string, error) {
+			return "", fmt.Errorf("adding host: %w", ErrHostAlreadyExists)
+		},
+		findHostFn: func(_ context.Context, _, _ string) (*HostEntry, error) {
+			return nil, nil // race: host disappeared
+		},
+	}
+
+	r := &HostMappingReconciler{
+		Client:     k8sClient,
+		Scheme:     s,
+		HostClient: mock,
+		Log:        slog.Default(),
+	}
+
+	result, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "my-host", Namespace: "default"},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, requeueDelayLong, result.RequeueAfter, "must requeue on adoption fallback")
+
+	var updated operatorv1alpha1.HostMapping
+	require.NoError(t, k8sClient.Get(context.Background(), types.NamespacedName{Name: "my-host", Namespace: "default"}, &updated))
+	assert.Equal(t, operatorv1alpha1.HostMappingPhaseError, updated.Status.Phase)
+	assert.Equal(t, "", updated.Status.HostID, "must not set HostID when adoption failed")
+
+	require.Len(t, updated.Status.Conditions, 1)
+	assert.Equal(t, metav1.ConditionFalse, updated.Status.Conditions[0].Status)
+	assert.Equal(t, "AdoptionFailed", updated.Status.Conditions[0].Reason)
 }

--- a/internal/storage/sqlite/eventstore.go
+++ b/internal/storage/sqlite/eventstore.go
@@ -19,6 +19,9 @@ const timeFormat = "2006-01-02T15:04:05.000Z"
 
 // AppendEvent appends a single event with optimistic concurrency control.
 func (s *Storage) AppendEvent(ctx context.Context, aggregateID ulid.ULID, event domain.EventEnvelope, expectedVersion int64) error {
+	if cerr := ctx.Err(); cerr != nil {
+		return oops.Wrapf(cerr, "append aborted: context already done")
+	}
 	conn, err := s.pool.Take(ctx)
 	if err != nil {
 		return oops.Wrapf(err, "take connection")
@@ -39,11 +42,20 @@ func (s *Storage) AppendEvent(ctx context.Context, aggregateID ulid.ULID, event 
 		return oops.Wrapf(err, "append event to aggregate %s", aggregateID)
 	}
 
+	// The deferred endFn(&err) commits only when err == nil. If the request
+	// deadline passed while we were working, force a rollback so a timed-out
+	// request does not silently persist (which would defeat OCC on retry — #330).
+	if err = ctx.Err(); err != nil {
+		return oops.Wrapf(err, "append aborted: context done before commit")
+	}
 	return nil
 }
 
 // AppendEvents appends multiple events atomically with optimistic concurrency control.
 func (s *Storage) AppendEvents(ctx context.Context, aggregateID ulid.ULID, events []domain.EventEnvelope, expectedVersion int64) error {
+	if cerr := ctx.Err(); cerr != nil {
+		return oops.Wrapf(cerr, "append aborted: context already done")
+	}
 	conn, err := s.pool.Take(ctx)
 	if err != nil {
 		return oops.Wrapf(err, "take connection")
@@ -66,6 +78,12 @@ func (s *Storage) AppendEvents(ctx context.Context, aggregateID ulid.ULID, event
 		}
 	}
 
+	// The deferred endFn(&err) commits only when err == nil. If the request
+	// deadline passed while we were working, force a rollback so a timed-out
+	// request does not silently persist (which would defeat OCC on retry — #330).
+	if err = ctx.Err(); err != nil {
+		return oops.Wrapf(err, "append aborted: context done before commit")
+	}
 	return nil
 }
 
@@ -73,6 +91,9 @@ func (s *Storage) AppendEvents(ctx context.Context, aggregateID ulid.ULID, event
 // single SQLite transaction. If any individual write fails (including a
 // version conflict), the entire transaction is rolled back.
 func (s *Storage) AppendEventsBatch(ctx context.Context, batch []storage.AggregateEvents) error {
+	if cerr := ctx.Err(); cerr != nil {
+		return oops.Wrapf(cerr, "batch append aborted: context already done")
+	}
 	conn, err := s.pool.Take(ctx)
 	if err != nil {
 		return oops.Wrapf(err, "take connection")
@@ -96,6 +117,12 @@ func (s *Storage) AppendEventsBatch(ctx context.Context, batch []storage.Aggrega
 		}
 	}
 
+	// The deferred endFn(&err) commits only when err == nil. If the request
+	// deadline passed while we were working, force a rollback so a timed-out
+	// request does not silently persist (which would defeat OCC on retry — #330).
+	if err = ctx.Err(); err != nil {
+		return oops.Wrapf(err, "batch append aborted: context done before commit")
+	}
 	return nil
 }
 

--- a/internal/storage/sqlite/legacy_migration.go
+++ b/internal/storage/sqlite/legacy_migration.go
@@ -271,12 +271,33 @@ func buildGoEventData(e rawLegacyEvent, meta *rustEventMetadata) (string, error)
 	return string(data), nil
 }
 
+// addSnapshotTriggerTypeColumn issues the ALTER TABLE to add trigger_type to
+// the snapshots table. SQLite requires a DEFAULT for NOT NULL on an added
+// column; existing rows backfill to "manual".
+// Callers MUST guard with columnExists before calling — this function does not
+// check for the column's existence.
+func addSnapshotTriggerTypeColumn(conn *sqlite.Conn) error {
+	return sqlitex.Execute(conn,
+		`ALTER TABLE snapshots ADD COLUMN trigger_type TEXT NOT NULL DEFAULT 'manual'`,
+		nil)
+}
+
 // migrateSnapshots rebuilds the snapshots table with the Go schema.
 // The Rust table has column "trigger" (TEXT) and created_at as INTEGER (epoch
 // micros), while Go expects "trigger_type" (TEXT) and created_at as TEXT (RFC3339).
 func migrateSnapshots(conn *sqlite.Conn, log *slog.Logger) (int, error) {
 	if !columnExists(conn, "snapshots", "trigger") {
-		log.Info("snapshots table already has Go schema, skipping snapshot migration")
+		// No Rust 'trigger' column. Check whether 'trigger_type' is also absent:
+		// this happens when a Go-era DB was created with an already-existing
+		// snapshots table that predated the trigger_type column (GH #331).
+		if !columnExists(conn, "snapshots", "trigger_type") {
+			log.Info("snapshots table missing trigger_type, adding column")
+			if err := addSnapshotTriggerTypeColumn(conn); err != nil {
+				return 0, oops.Wrapf(err, "add trigger_type column to snapshots")
+			}
+		} else {
+			log.Info("snapshots table already has Go schema, skipping snapshot migration")
+		}
 		return 0, nil
 	}
 

--- a/internal/storage/sqlite/pool_error_test.go
+++ b/internal/storage/sqlite/pool_error_test.go
@@ -236,6 +236,131 @@ func TestApplyRetentionPolicy_TakeError(t *testing.T) {
 	require.ErrorContains(t, err, "take connection")
 }
 
+// ---------- EventStore: context cancelled mid-flight (#330) ----------
+//
+// noInterruptPool wraps a real ConnPool and, on each successful Take:
+//  1. Strips the SQLite interrupt from the connection (SetInterrupt(nil)).
+//  2. Calls onTake (if non-nil), which the test uses to cancel the context.
+//
+// This reproduces the production failure window: zombiezen's pool wires the
+// context's Done channel to sqlite3_interrupt, so the interrupt only fires on
+// the *next* SQLite call. If the context deadline expires in the tiny gap
+// between the last successful INSERT and the `return nil`, no new SQLite call
+// is made, so the interrupt never fires and the deferred endFn commits with
+// err==nil. By stripping the interrupt first we make that window observable
+// and deterministic: all SQL succeeds, then we cancel the context, then the
+// pre-commit guard is the only thing that can catch it.
+type noInterruptPool struct {
+	inner  ConnPool
+	onTake func() // called after stripping interrupt, e.g. to cancel testCtx
+}
+
+func (p *noInterruptPool) Take(ctx context.Context) (*sqlib.Conn, error) {
+	conn, err := p.inner.Take(ctx)
+	if err != nil {
+		return nil, err
+	}
+	conn.SetInterrupt(nil) // strip interrupt so ctx cancellation won't abort SQL
+	if p.onTake != nil {
+		p.onTake() // simulate deadline expiry in the last-write→return nil window
+	}
+	return conn, nil
+}
+
+func (p *noInterruptPool) Put(conn *sqlib.Conn) { p.inner.Put(conn) }
+func (p *noInterruptPool) Close() error         { return p.inner.Close() }
+
+// newNoInterruptStore builds a Storage that strips the connection interrupt and
+// runs onTake after each successful Take, plus a read-only Storage on the same
+// pool for count assertions.
+func newNoInterruptStore(t *testing.T, onTake func()) (write *Storage, read *Storage) {
+	t.Helper()
+	real, err := New("file::memory:?mode=memory&cache=shared", slog.Default())
+	require.NoError(t, err)
+	require.NoError(t, real.Initialize(context.Background()))
+	t.Cleanup(func() { _ = real.pool.Close() })
+
+	write = &Storage{pool: &noInterruptPool{inner: real.pool, onTake: onTake}, log: slog.Default()}
+	read = real
+	return write, read
+}
+
+// TestAppendEvent_ContextExpiredBeforeCommit verifies that AppendEvent rolls
+// back and returns an error when the request context expires in the window
+// between the final INSERT and the deferred commit (pre-commit guard — #330).
+//
+// Without the guard, the deferred endFn sees err==nil and commits; the data
+// is persisted even though the caller already received a deadline/cancel error.
+func TestAppendEvent_ContextExpiredBeforeCommit(t *testing.T) {
+	testCtx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	s, real := newNoInterruptStore(t, cancel)
+
+	aggID := ulid.Make()
+	now := time.Now().UTC()
+	env := makeEnvelope(aggID, domain.HostCreated{
+		IPAddress: "10.0.0.1", Hostname: "precommit-single.local",
+		Aliases: []string{}, Tags: []string{}, CreatedAt: now,
+	}, 1, now)
+
+	err := s.AppendEvent(testCtx, aggID, env, 0)
+	require.Error(t, err, "AppendEvent must return error when ctx expires before commit (#330)")
+
+	count, countErr := real.CountEvents(context.Background(), aggID)
+	require.NoError(t, countErr)
+	require.Equal(t, int64(0), count, "AppendEvent must not commit data when ctx expires before commit (#330)")
+}
+
+// TestAppendEvents_ContextExpiredBeforeCommit is the multi-event variant of
+// TestAppendEvent_ContextExpiredBeforeCommit.
+func TestAppendEvents_ContextExpiredBeforeCommit(t *testing.T) {
+	testCtx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	s, real := newNoInterruptStore(t, cancel)
+
+	aggID := ulid.Make()
+	now := time.Now().UTC()
+	env1 := makeEnvelope(aggID, domain.HostCreated{
+		IPAddress: "10.0.0.1", Hostname: "precommit-multi-a.local",
+		Aliases: []string{}, Tags: []string{}, CreatedAt: now,
+	}, 1, now)
+	env2 := makeEnvelope(aggID, domain.IPAddressChanged{
+		OldIP: "10.0.0.1", NewIP: "10.0.0.2", ChangedAt: now.Add(time.Second),
+	}, 2, now.Add(time.Second))
+
+	err := s.AppendEvents(testCtx, aggID, []domain.EventEnvelope{env1, env2}, 0)
+	require.Error(t, err, "AppendEvents must return error when ctx expires before commit (#330)")
+
+	count, countErr := real.CountEvents(context.Background(), aggID)
+	require.NoError(t, countErr)
+	require.Equal(t, int64(0), count, "AppendEvents must not commit data when ctx expires before commit (#330)")
+}
+
+// TestAppendEventsBatch_ContextExpiredBeforeCommit is the batch variant of
+// TestAppendEvent_ContextExpiredBeforeCommit.
+func TestAppendEventsBatch_ContextExpiredBeforeCommit(t *testing.T) {
+	testCtx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	s, real := newNoInterruptStore(t, cancel)
+
+	aggID := ulid.Make()
+	now := time.Now().UTC()
+	env := makeEnvelope(aggID, domain.HostCreated{
+		IPAddress: "10.0.0.1", Hostname: "precommit-batch.local",
+		Aliases: []string{}, Tags: []string{}, CreatedAt: now,
+	}, 1, now)
+	batch := []storage.AggregateEvents{
+		{AggregateID: aggID, Events: []domain.EventEnvelope{env}, ExpectedVersion: 0},
+	}
+
+	err := s.AppendEventsBatch(testCtx, batch)
+	require.Error(t, err, "AppendEventsBatch must return error when ctx expires before commit (#330)")
+
+	count, countErr := real.CountEvents(context.Background(), aggID)
+	require.NoError(t, countErr)
+	require.Equal(t, int64(0), count, "AppendEventsBatch must not commit data when ctx expires before commit (#330)")
+}
+
 // ---------- SnapshotStore: ImmediateTransaction error branch ----------
 
 func TestApplyRetentionPolicy_TransactionError(t *testing.T) {

--- a/internal/storage/sqlite/snapshot_schema_migration_test.go
+++ b/internal/storage/sqlite/snapshot_schema_migration_test.go
@@ -1,0 +1,248 @@
+package sqlite
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/oklog/ulid/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	sqlib "zombiezen.com/go/sqlite"
+	"zombiezen.com/go/sqlite/sqlitex"
+
+	"github.com/fzymgc-house/router-hosts/internal/domain"
+)
+
+// newGoPoolWithConn creates a pool + returns a held connection (caller must Put it back).
+// The pool is registered for cleanup. The connection is NOT put back until the
+// test calls pool.Put — callers that need to return the conn before calling
+// store methods should do so explicitly.
+func newGoPoolWithConn(t *testing.T) (*sqlitex.Pool, *sqlib.Conn) {
+	t.Helper()
+	pool, err := sqlitex.NewPool("file::memory:?mode=memory&cache=shared", sqlitex.PoolOptions{PoolSize: 1})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, pool.Close()) })
+
+	conn, err := pool.Take(context.Background())
+	require.NoError(t, err)
+	return pool, conn
+}
+
+// createGoTablesWithoutTriggerType creates the Go events/schema_version tables and a
+// snapshots table that deliberately omits trigger_type (and trigger). This
+// reproduces the #331 production case: the DB was created by a Go-era deploy
+// whose migration 001 no-oped because snapshots already existed from a prior
+// run that lacked trigger_type.
+func createGoTablesWithoutTriggerType(t *testing.T, conn *sqlib.Conn) {
+	t.Helper()
+	ddl := `
+		CREATE TABLE events (
+			event_id TEXT PRIMARY KEY,
+			aggregate_id TEXT NOT NULL,
+			event_type TEXT NOT NULL,
+			event_data TEXT NOT NULL,
+			event_version INTEGER NOT NULL,
+			created_at TEXT NOT NULL,
+			created_by TEXT
+		);
+		CREATE INDEX idx_events_aggregate ON events(aggregate_id, event_version);
+		CREATE INDEX idx_events_created_at ON events(created_at);
+
+		CREATE TABLE snapshots (
+			snapshot_id TEXT PRIMARY KEY,
+			created_at TEXT NOT NULL,
+			hosts_content TEXT NOT NULL,
+			entry_count INTEGER NOT NULL,
+			name TEXT,
+			event_log_position INTEGER,
+			entries_json TEXT
+		);
+		CREATE INDEX idx_snapshots_created_at ON snapshots(created_at);
+
+		CREATE TABLE schema_version (
+			version INTEGER PRIMARY KEY,
+			applied_at TEXT NOT NULL
+		);
+		INSERT INTO schema_version (version, applied_at) VALUES (1, datetime('now'));
+		INSERT INTO schema_version (version, applied_at) VALUES (2, datetime('now'));
+		INSERT INTO schema_version (version, applied_at) VALUES (3, datetime('now'));
+	`
+	require.NoError(t, sqlitex.ExecuteScript(conn, ddl, nil))
+}
+
+// TestGH331_GoEraDBMissingTriggerType is the primary regression test for #331.
+// It reproduces a Go-era database where snapshots was created without trigger_type
+// (no host_events table, so the legacy path is a no-op) and verifies Initialize
+// repairs the schema and a full round-trip works.
+func TestGH331_GoEraDBMissingTriggerType(t *testing.T) {
+	pool, conn := newGoPoolWithConn(t)
+	createGoTablesWithoutTriggerType(t, conn)
+	pool.Put(conn)
+
+	store := &Storage{pool: pool, log: slog.Default()}
+	ctx := context.Background()
+
+	// This MUST succeed after the fix; it fails against unpatched code because
+	// repairSnapshotTriggerType / version-4 migration don't exist yet.
+	require.NoError(t, store.Initialize(ctx))
+
+	// Verify trigger_type column was added.
+	err := store.withConn(ctx, func(c *sqlib.Conn) error {
+		assert.True(t, columnExists(c, "snapshots", "trigger_type"),
+			"trigger_type column must exist after Initialize")
+		return nil
+	})
+	require.NoError(t, err)
+
+	// Full round-trip: SaveSnapshot then ListSnapshots must not error.
+	snap := domain.NewSnapshot(ulid.Make(), "127.0.0.1 localhost\n", "manual", nil, nil)
+	snap.CreatedAt = time.Now().UTC()
+	require.NoError(t, store.SaveSnapshot(ctx, *snap))
+
+	metas, err := store.ListSnapshots(ctx, nil, nil)
+	require.NoError(t, err)
+	require.Len(t, metas, 1)
+	assert.Equal(t, snap.SnapshotID, metas[0].SnapshotID)
+	assert.Equal(t, "manual", metas[0].Trigger)
+}
+
+// TestGH331_LegacyPath_NeitherColumn verifies Part 2: when the legacy migration
+// runs on a DB that has host_events AND a snapshots table missing both trigger
+// and trigger_type, Initialize adds trigger_type.
+func TestGH331_LegacyPath_NeitherColumn(t *testing.T) {
+	pool, conn := newGoPoolWithConn(t)
+
+	// Build a schema with host_events AND a snapshots table missing both columns.
+	ddl := `
+		CREATE TABLE host_events (
+			event_id TEXT PRIMARY KEY,
+			aggregate_id TEXT NOT NULL,
+			event_type TEXT NOT NULL,
+			event_version TEXT NOT NULL,
+			ip_address TEXT,
+			hostname TEXT,
+			comment TEXT,
+			tags TEXT,
+			aliases TEXT,
+			event_timestamp INTEGER NOT NULL,
+			metadata TEXT NOT NULL,
+			created_at INTEGER NOT NULL,
+			created_by TEXT
+		);
+		CREATE TABLE snapshots (
+			snapshot_id TEXT PRIMARY KEY,
+			created_at TEXT NOT NULL,
+			hosts_content TEXT NOT NULL,
+			entry_count INTEGER NOT NULL,
+			name TEXT,
+			event_log_position INTEGER
+		);
+		CREATE TABLE _sqlx_migrations (version INTEGER PRIMARY KEY, description TEXT NOT NULL, installed_on TEXT NOT NULL, success INTEGER NOT NULL);
+	`
+	require.NoError(t, sqlitex.ExecuteScript(conn, ddl, nil))
+
+	// Run migration SQL files (creates events + schema_version alongside existing tables).
+	for _, m := range migrationFiles {
+		sql, readErr := migrations.ReadFile(m.path)
+		require.NoError(t, readErr)
+		require.NoError(t, sqlitex.ExecuteScript(conn, string(sql), nil))
+	}
+	pool.Put(conn)
+
+	store := &Storage{pool: pool, log: slog.Default()}
+	ctx := context.Background()
+	require.NoError(t, store.Initialize(ctx))
+
+	err := store.withConn(ctx, func(c *sqlib.Conn) error {
+		assert.True(t, columnExists(c, "snapshots", "trigger_type"),
+			"trigger_type must exist after legacy path handles neither-column case")
+		return nil
+	})
+	require.NoError(t, err)
+
+	// The schema can be structurally complete yet still misbehave at the data
+	// layer, so exercise the real create/list path the way #331 broke it.
+	snap := domain.NewSnapshot(ulid.Make(), "127.0.0.1 localhost\n", "manual", nil, nil)
+	snap.CreatedAt = time.Now().UTC()
+	require.NoError(t, store.SaveSnapshot(ctx, *snap))
+
+	metas, err := store.ListSnapshots(ctx, nil, nil)
+	require.NoError(t, err)
+	require.Len(t, metas, 1)
+	assert.Equal(t, "manual", metas[0].Trigger)
+}
+
+// TestAssertSnapshotsSchema_MissingTriggerType verifies Part 3 directly: calling
+// assertSnapshotsSchema on a snapshots table that lacks trigger_type returns a
+// descriptive error (the repair path does not mask it here).
+func TestAssertSnapshotsSchema_MissingTriggerType(t *testing.T) {
+	pool, conn := newGoPoolWithConn(t)
+	defer pool.Put(conn)
+
+	// Create snapshots without trigger_type.
+	require.NoError(t, sqlitex.ExecuteScript(conn, `
+		CREATE TABLE snapshots (
+			snapshot_id TEXT PRIMARY KEY,
+			created_at TEXT NOT NULL,
+			hosts_content TEXT NOT NULL,
+			entry_count INTEGER NOT NULL,
+			name TEXT,
+			event_log_position INTEGER
+		);
+	`, nil))
+
+	err := assertSnapshotsSchema(conn)
+	require.Error(t, err, "assertSnapshotsSchema must fail when trigger_type is missing")
+	assert.Contains(t, err.Error(), "trigger_type")
+}
+
+// TestAssertSnapshotsSchema_MissingTable verifies Part 3: missing snapshots table
+// is also an assertion failure.
+func TestAssertSnapshotsSchema_MissingTable(t *testing.T) {
+	pool, conn := newGoPoolWithConn(t)
+	defer pool.Put(conn)
+
+	err := assertSnapshotsSchema(conn)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "snapshots")
+}
+
+// TestInitialize_HealthyDB_Idempotent verifies no regression: a fresh healthy DB
+// survives Initialize called twice with no errors.
+func TestInitialize_HealthyDB_Idempotent(t *testing.T) {
+	store, err := New("file::memory:?mode=memory&cache=shared", slog.Default())
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, store.Close()) })
+
+	ctx := context.Background()
+	require.NoError(t, store.Initialize(ctx), "first Initialize")
+	require.NoError(t, store.Initialize(ctx), "second Initialize must be idempotent")
+
+	// Confirm trigger_type exists on a clean DB.
+	err = store.withConn(ctx, func(c *sqlib.Conn) error {
+		assert.True(t, columnExists(c, "snapshots", "trigger_type"))
+		return nil
+	})
+	require.NoError(t, err)
+}
+
+// TestInitialize_Version4_Recorded verifies the repair migration version (4) is
+// recorded in schema_version after Initialize on a repaired DB.
+func TestInitialize_Version4_Recorded(t *testing.T) {
+	pool, conn := newGoPoolWithConn(t)
+	createGoTablesWithoutTriggerType(t, conn)
+	pool.Put(conn)
+
+	store := &Storage{pool: pool, log: slog.Default()}
+	ctx := context.Background()
+	require.NoError(t, store.Initialize(ctx))
+
+	err := store.withConn(ctx, func(c *sqlib.Conn) error {
+		assert.True(t, isMigrationApplied(c, snapshotTriggerRepairVersion),
+			"version 4 must be recorded after repair")
+		return nil
+	})
+	require.NoError(t, err)
+}

--- a/internal/storage/sqlite/sqlite.go
+++ b/internal/storage/sqlite/sqlite.go
@@ -50,6 +50,12 @@ func New(dbPath string, logger *slog.Logger) (*Storage, error) {
 // BackendName returns the storage backend identifier.
 func (s *Storage) BackendName() string { return "sqlite" }
 
+// snapshotTriggerRepairVersion is the schema version recorded after the
+// idempotent repair that adds trigger_type to any snapshots table that
+// was created without it (GH #331). Version 3 is taken by the legacy
+// Rust migration; this uses 4.
+const snapshotTriggerRepairVersion = 4
+
 // migrationFiles lists migration SQL files in order. Each file is applied
 // only when the schema_version table does not yet contain that version number.
 var migrationFiles = []struct {
@@ -91,7 +97,19 @@ func (s *Storage) Initialize(ctx context.Context) error {
 			}
 		}
 
-		return nil
+		// Repair: add trigger_type to snapshots if it was created without it
+		// (GH #331). Runs after the legacy migration so the two paths do not
+		// conflict. The columnExists guard makes this fully idempotent.
+		if !isMigrationApplied(conn, snapshotTriggerRepairVersion) {
+			if err := repairSnapshotTriggerType(conn, s.log); err != nil {
+				return oops.Wrapf(err, "repair snapshots trigger_type column")
+			}
+			if err := recordMigrationVersion(conn, snapshotTriggerRepairVersion); err != nil {
+				return err
+			}
+		}
+
+		return assertSnapshotsSchema(conn)
 	})
 }
 
@@ -115,6 +133,47 @@ func recordMigrationVersion(conn *sqlite.Conn, version int) error {
 	return sqlitex.Execute(conn,
 		`INSERT OR IGNORE INTO schema_version (version, applied_at) VALUES (?, datetime('now'))`,
 		&sqlitex.ExecOptions{Args: []any{version}})
+}
+
+// repairSnapshotTriggerType adds trigger_type to the snapshots table when the
+// table exists but lacks the column AND also lacks the Rust-era 'trigger'
+// column (the legacy migration path handles that case). Fully idempotent.
+func repairSnapshotTriggerType(conn *sqlite.Conn, log *slog.Logger) error {
+	if !tableExists(conn, "snapshots") {
+		return nil
+	}
+	if columnExists(conn, "snapshots", "trigger_type") {
+		return nil // already correct
+	}
+	if columnExists(conn, "snapshots", "trigger") {
+		// Unreachable in a valid migration state: the legacy migration (run
+		// earlier in Initialize) rebuilds the table whenever a Rust-era
+		// 'trigger' column is present. If we still see it here, the DB is in
+		// an unexpected hand-modified state; warn so the assertSnapshotsSchema
+		// failure that follows is not mistaken for a code bug.
+		log.Warn("snapshots has legacy 'trigger' column but no 'trigger_type' after legacy migration; leaving repair to legacy path")
+		return nil
+	}
+	return addSnapshotTriggerTypeColumn(conn)
+}
+
+// assertSnapshotsSchema verifies the snapshots table has all required Go columns.
+// Returns a descriptive error if the table is absent or any column is missing,
+// so the server refuses to start rather than failing per-request at runtime.
+func assertSnapshotsSchema(conn *sqlite.Conn) error {
+	if !tableExists(conn, "snapshots") {
+		return oops.Errorf("startup schema assertion failed: snapshots table does not exist")
+	}
+	required := []string{
+		"snapshot_id", "created_at", "hosts_content", "entry_count",
+		"trigger_type", "name", "event_log_position", "entries_json",
+	}
+	for _, col := range required {
+		if !columnExists(conn, "snapshots", col) {
+			return oops.Errorf("startup schema assertion failed: snapshots table missing required column %q", col)
+		}
+	}
+	return nil
 }
 
 // HealthCheck verifies the database connection is alive.

--- a/internal/storage/sqlite/sqlite_test.go
+++ b/internal/storage/sqlite/sqlite_test.go
@@ -1141,6 +1141,77 @@ func (s *StorageSuite) TestListAllUnknownEventTypeInDBReturnsError() {
 	s.Require().Error(err, "GetByID must return an error for an unknown event type in the DB")
 }
 
+// ---------- Regression tests: context cancellation must not commit (#330) ----------
+
+// TestAppendEventCancelledContextDoesNotPersist verifies that AppendEvent
+// returns an error and does not persist data when the context is already
+// cancelled before the call (start-of-function guard — #330).
+func (s *StorageSuite) TestAppendEventCancelledContextDoesNotPersist() {
+	aggID := ulid.Make()
+	now := time.Now().UTC().Truncate(time.Millisecond)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancel immediately before calling
+
+	env := s.createHostEvents(aggID, "10.0.0.1", "cancelled-append.local", now)
+	err := s.store.AppendEvent(ctx, aggID, env, 0)
+	s.Require().Error(err)
+
+	count, countErr := s.store.CountEvents(context.Background(), aggID)
+	s.Require().NoError(countErr)
+	s.Require().Equal(int64(0), count)
+}
+
+// TestAppendEventsCancelledContextDoesNotPersist verifies that AppendEvents
+// returns an error and does not persist data when the context is already
+// cancelled before the call (start-of-function guard — #330).
+func (s *StorageSuite) TestAppendEventsCancelledContextDoesNotPersist() {
+	aggID := ulid.Make()
+	now := time.Now().UTC().Truncate(time.Millisecond)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancel immediately before calling
+
+	env1 := s.createHostEvents(aggID, "10.0.0.1", "cancelled-appends-a.local", now)
+	env2 := makeEnvelope(aggID, domain.IPAddressChanged{
+		OldIP:     "10.0.0.1",
+		NewIP:     "10.0.0.2",
+		ChangedAt: now.Add(time.Second),
+	}, 2, now.Add(time.Second))
+	err := s.store.AppendEvents(ctx, aggID, []domain.EventEnvelope{env1, env2}, 0)
+	s.Require().Error(err)
+
+	count, countErr := s.store.CountEvents(context.Background(), aggID)
+	s.Require().NoError(countErr)
+	s.Require().Equal(int64(0), count)
+}
+
+// TestAppendEventsBatchCancelledContextDoesNotPersist verifies that
+// AppendEventsBatch returns an error and does not persist data when the
+// context is already cancelled before the call (start-of-function guard — #330).
+func (s *StorageSuite) TestAppendEventsBatchCancelledContextDoesNotPersist() {
+	aggID := ulid.Make()
+	now := time.Now().UTC().Truncate(time.Millisecond)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancel immediately before calling
+
+	env := s.createHostEvents(aggID, "10.0.0.1", "cancelled-batch.local", now)
+	batch := []storage.AggregateEvents{
+		{
+			AggregateID:     aggID,
+			Events:          []domain.EventEnvelope{env},
+			ExpectedVersion: 0,
+		},
+	}
+	err := s.store.AppendEventsBatch(ctx, batch)
+	s.Require().Error(err)
+
+	count, countErr := s.store.CountEvents(context.Background(), aggID)
+	s.Require().NoError(countErr)
+	s.Require().Equal(int64(0), count)
+}
+
 // containsStr is a helper that avoids a testify import in standalone test
 // functions.
 func containsStr(s, substr string) bool {


### PR DESCRIPTION
## Summary

Remediates the production **aggregate-bloat runaway** uncovered during triage of #330/#323/#331/#313 (verified against `main` v0.10.5). A host aggregate had reached ~91k events because every "failed" operator retry silently committed another event. This PR lands the three bounded fixes that break that feedback loop. The larger snapshot-accelerated rehydration + compaction feature (the rest of #330) is being designed separately and is **not** in this PR.

## What's fixed

| Commit | Fix | Issue |
|--------|-----|-------|
| `fix(storage): do not commit past deadline in event append` | `AppendEvent`/`AppendEvents` now guard on the request context at start **and** immediately before commit, rolling back instead of committing past the gRPC deadline. This is the *engine* of the runaway — a write that times out no longer silently commits. | #330 (commit-on-timeout part) |
| `fix(storage): repair snapshots trigger_type column and add startup assertion` | Idempotent v4 migration that adds `snapshots.trigger_type` when absent (independent of the legacy Rust `trigger` path), broadened `migrateSnapshots` to the "neither column" case, plus a startup schema assertion so a code/schema mismatch fails loudly at boot instead of at first `snapshot` call. | Fixes #331 |
| `fix(operator): make reconcile idempotent on AlreadyExists via host adoption` | Reconcile adopts an existing host on `AlreadyExists` (via `FindHost`) instead of erroring, breaking the `UpdateHost` hot-loop — the *trigger* that fed the commit-on-timeout runaway. | Fixes #313 |

## Why one PR

The three are a single causal chain (#313 trigger → retry storm → #330 commit-on-timeout engine), and they fix an **active** production degradation, so they ship together rather than waiting on the compaction design.

## Verification

Each fix was implemented and committed independently, two-stage reviewed (spec-compliance + code-quality), and gate-verified:

- `task lint` → 0 issues, buf clean
- `task test` → all packages pass **with the race detector**
- Regression tests added for every fix (935 insertions, ~730 of which are tests): both ctx guards in event append, the snapshot schema migration (incl. "neither column" and idempotency), and the operator adoption path.

## Scope / follow-ups (not in this PR)

- **#330 (remaining):** snapshot-accelerated rehydration + event-log compaction/GC — a 4-feature architectural change pending a design pass (truncation-vs-time-travel is a product decision). Tracked in bead `router-hosts-eda.2`.
- **#323:** end-to-end verification that the wedge no longer recurs — gated on the compaction work. Tracked in `router-hosts-eda.5`.

Partially addresses #330. Relates to #323.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
