### PR TITLE
fix(server): compact dry-run preview + over-threshold guard

### DIFF
--- a/internal/server/commands_test.go
+++ b/internal/server/commands_test.go
@@ -543,7 +543,11 @@ func seedBloated(t *testing.T, ctx context.Context, store storage.Storage, n int
 func newCompactTestStore(t *testing.T) (storage.Storage, context.Context) {
 	t.Helper()
 	ctx := context.Background()
-	store, err := sqlite.New("file::memory:?mode=memory&cache=shared", slog.Default())
+	// Per-test-unique in-memory DB name: the unnamed shared-cache URI is
+	// process-global, so parallel tests sharing it would see each other's
+	// aggregates. t.Name() isolates each test's store.
+	dsn := fmt.Sprintf("file:%s?mode=memory&cache=shared", t.Name())
+	store, err := sqlite.New(dsn, slog.Default())
 	require.NoError(t, err)
 	require.NoError(t, store.Initialize(ctx))
 	t.Cleanup(func() { _ = store.Close() })

--- a/internal/server/service.go
+++ b/internal/server/service.go
@@ -514,7 +514,8 @@ func (s *HostsServiceImpl) ImportHosts(stream grpc.BidiStreamingServer[hostsv1.I
 				stats.Failed++
 				stats.ValidationErrors = append(stats.ValidationErrors,
 					fmt.Sprintf("Entry %d (%s -> %s): %v", i+1, entry.IP, entry.Hostname, addErr))
-				slog.Error("import entry failed due to storage or infrastructure error",
+				slog.Error(
+					"import entry failed due to storage or infrastructure error",
 					"entry_index", i+1,
 					"ip", entry.IP,
 					"hostname", entry.Hostname,
@@ -532,7 +533,8 @@ func (s *HostsServiceImpl) ImportHosts(stream grpc.BidiStreamingServer[hostsv1.I
 	}
 
 	if stats.Failed > 0 {
-		slog.Warn("import completed with failures",
+		slog.Warn(
+			"import completed with failures",
 			"processed", stats.Processed,
 			"failed", stats.Failed,
 			"created", stats.Created,
@@ -896,6 +898,10 @@ func (s *HostsServiceImpl) CompactAggregates(ctx context.Context, req *hostsv1.C
 			results = []storage.CompactResult{res}
 		}
 	case *hostsv1.CompactAggregatesRequest_OverThreshold:
+		if t.OverThreshold <= 0 {
+			return nil, status.Errorf(codes.InvalidArgument,
+				"over_threshold must be > 0, got %d (a non-positive threshold would compact every aggregate)", t.OverThreshold)
+		}
 		if req.GetDryRun() {
 			res, derr := s.dryRunOver(ctx, t.OverThreshold)
 			if derr != nil {
@@ -928,7 +934,20 @@ func (s *HostsServiceImpl) CompactAggregates(ctx context.Context, req *hostsv1.C
 	return resp, nil
 }
 
-// dryRunOne reports counts without mutating (events_after = events_before).
+// projectedCompactedCount returns the event count an aggregate would have AFTER
+// compaction: a single seed event when it currently has more than one event,
+// otherwise unchanged (compaction is a no-op for <=1 event). Used by the
+// dry-run paths so a preview reports the savings the real compaction would make.
+func projectedCompactedCount(count int64) int64 {
+	if count > 1 {
+		return 1
+	}
+	return count
+}
+
+// dryRunOne previews compacting one aggregate without mutating: events_after is
+// the projected post-compaction count (1 for an aggregate with >1 event), so
+// TotalEventsReclaimed reflects the savings the real compaction would make.
 func (s *HostsServiceImpl) dryRunOne(ctx context.Context, id ulid.ULID) (storage.CompactResult, error) {
 	count, err := s.store.CountEvents(ctx, id)
 	if err != nil {
@@ -938,7 +957,7 @@ func (s *HostsServiceImpl) dryRunOne(ctx context.Context, id ulid.ULID) (storage
 	if err != nil {
 		return storage.CompactResult{}, err
 	}
-	return storage.CompactResult{AggregateID: id, EventsBefore: count, EventsAfter: count, Version: v}, nil
+	return storage.CompactResult{AggregateID: id, EventsBefore: count, EventsAfter: projectedCompactedCount(count), Version: v}, nil
 }
 
 // dryRunOver reports which aggregates exceed threshold without mutating.
@@ -958,7 +977,7 @@ func (s *HostsServiceImpl) dryRunOver(ctx context.Context, threshold int64) ([]s
 			if verr != nil {
 				return nil, verr
 			}
-			out = append(out, storage.CompactResult{AggregateID: id, EventsBefore: count, EventsAfter: count, Version: v})
+			out = append(out, storage.CompactResult{AggregateID: id, EventsBefore: count, EventsAfter: projectedCompactedCount(count), Version: v})
 		}
 	}
 	return out, nil

--- a/internal/server/service_test.go
+++ b/internal/server/service_test.go
@@ -1957,7 +1957,8 @@ func TestService_RegenerateOutputs_MaterializesWithoutMutation(t *testing.T) {
 	require.NoFileExists(t, hostsPath)
 	require.NoFileExists(t, confPath)
 
-	svc := NewHostsServiceImpl(handler, store,
+	svc := NewHostsServiceImpl(
+		handler, store,
 		WithHostsGenerator(NewHostsFileGenerator(hostsPath)),
 		WithDnsmasqGenerator(NewDnsmasqConfGenerator(confPath)),
 	)
@@ -2011,8 +2012,8 @@ func TestService_CompactAggregates_DryRunSingle(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, resp.GetCompacted(), 1)
 	require.Equal(t, int64(8), resp.GetCompacted()[0].GetEventsBefore())
-	require.Equal(t, int64(8), resp.GetCompacted()[0].GetEventsAfter())
-	require.Equal(t, int64(0), resp.GetTotalEventsReclaimed())
+	require.Equal(t, int64(1), resp.GetCompacted()[0].GetEventsAfter()) // projected post-compaction count
+	require.Equal(t, int64(7), resp.GetTotalEventsReclaimed())          // 8 -> 1 would reclaim 7
 
 	// dry-run must not mutate the event store
 	cnt, err := env.store.CountEvents(ctx, id)
@@ -2053,9 +2054,9 @@ func TestService_CompactAggregates_DryRunOver(t *testing.T) {
 	require.Len(t, resp.GetCompacted(), 1)
 	require.Equal(t, big.String(), resp.GetCompacted()[0].GetAggregateId())
 	require.Equal(t, int64(12), resp.GetCompacted()[0].GetEventsBefore())
-	require.Equal(t, int64(12), resp.GetCompacted()[0].GetEventsAfter()) // dry-run: no reduction
-	require.Equal(t, int64(12), resp.GetCompacted()[0].GetVersion())     // high-water version reported, not 0
-	require.Equal(t, int64(0), resp.GetTotalEventsReclaimed())
+	require.Equal(t, int64(1), resp.GetCompacted()[0].GetEventsAfter()) // projected: 12 -> 1
+	require.Equal(t, int64(12), resp.GetCompacted()[0].GetVersion())    // high-water version reported, not 0
+	require.Equal(t, int64(11), resp.GetTotalEventsReclaimed())         // 12 -> 1 would reclaim 11
 
 	// dry-run must not mutate either aggregate
 	cntBig, err := env.store.CountEvents(ctx, big)
@@ -2071,4 +2072,22 @@ func TestService_CompactAggregates_NoTarget(t *testing.T) {
 	_, err := env.client.CompactAggregates(context.Background(), &hostsv1.CompactAggregatesRequest{})
 	require.Error(t, err)
 	require.Equal(t, codes.InvalidArgument, status.Code(err))
+}
+
+func TestService_CompactAggregates_OverThresholdZero(t *testing.T) {
+	env := newServiceTestEnv(t)
+	ctx := context.Background()
+	id := seedBloated(t, ctx, env.store, 3)
+
+	// over_threshold <= 0 must be rejected, not silently compact every aggregate.
+	_, err := env.client.CompactAggregates(ctx, &hostsv1.CompactAggregatesRequest{
+		Target: &hostsv1.CompactAggregatesRequest_OverThreshold{OverThreshold: 0},
+	})
+	require.Error(t, err)
+	require.Equal(t, codes.InvalidArgument, status.Code(err))
+
+	// the aggregate must remain untouched
+	cnt, err := env.store.CountEvents(ctx, id)
+	require.NoError(t, err)
+	require.Equal(t, int64(3), cnt)
 }


### PR DESCRIPTION
## Summary

Post-merge review of #336 (epic `router-hosts-eda.2.1`) surfaced two issues in the `CompactAggregates` gRPC handler; this addresses both:

- **Dry-run preview was uninformative** (review finding `router-hosts-ndq.2`, important): `dryRunOne` / `dryRunOver` set `events_after = events_before`, so the projected `total_events_reclaimed` was always **0** and the CLI printed "total events that would be reclaimed: 0". An operator could not use `--dry-run` to assess savings. Dry-run now projects the post-compaction count (`1` for an aggregate with >1 event), so the preview reflects the savings the real compaction would make. The dry-run paths remain strictly non-mutating.
- **`over_threshold <= 0` was accepted** (review finding `router-hosts-ndq.1`): `compact --over 0` would compact *every* aggregate (every count > 0). The handler now rejects `over_threshold <= 0` with `InvalidArgument` (covering both the real and dry-run over-threshold paths).

## Test Plan

- [x] `task test` green (all packages, race detector)
- [x] `task lint` clean (0 issues)
- [x] `TestService_CompactAggregates_DryRunSingle` / `_DryRunOver` updated to assert projected savings (8→1 reclaims 7; 12→1 reclaims 11) and still prove non-mutation
- [x] New `TestService_CompactAggregates_OverThresholdZero` asserts `--over 0` → `InvalidArgument` and leaves the aggregate untouched
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
