### PR TITLE
fix(operator): IngressRoute recreate symmetry + Recreated event

### DIFF
--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -98,6 +98,7 @@ func run() error {
 		Scheme:     mgr.GetScheme(),
 		HostClient: hostClient,
 		Log:        logger.With("controller", "hostmapping"),
+		Recorder:   mgr.GetEventRecorder("hostmapping-controller"),
 	}).SetupWithManager(mgr); err != nil {
 		logger.Error("unable to create HostMapping controller", "error", err)
 		return err

--- a/go.mod
+++ b/go.mod
@@ -21,6 +21,7 @@ require (
 	golang.org/x/term v0.43.0
 	google.golang.org/grpc v1.81.1
 	google.golang.org/protobuf v1.36.12-0.20260120151049-f2248ac996af
+	k8s.io/api v0.36.1
 	k8s.io/apimachinery v0.36.1
 	k8s.io/client-go v0.36.1
 	pgregory.net/rapid v1.3.0
@@ -112,7 +113,6 @@ require (
 	gopkg.in/evanphx/json-patch.v4 v4.13.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
-	k8s.io/api v0.36.1 // indirect
 	k8s.io/apiextensions-apiserver v0.36.1 // indirect
 	k8s.io/klog/v2 v2.140.0 // indirect
 	k8s.io/kube-openapi v0.0.0-20260603220949-865597e52e25 // indirect

--- a/internal/operator/hostmapping_controller.go
+++ b/internal/operator/hostmapping_controller.go
@@ -9,8 +9,10 @@ import (
 	"time"
 
 	"github.com/samber/oops"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/events"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -34,6 +36,11 @@ type HostMappingReconciler struct {
 	Scheme     *runtime.Scheme
 	HostClient HostClient
 	Log        *slog.Logger
+
+	// Recorder emits Kubernetes Events for corrective actions (e.g. recreating
+	// a host deleted out-of-band). It may be nil in tests that do not assert on
+	// events; event emission is best-effort telemetry, never control flow.
+	Recorder events.EventRecorder
 }
 
 // +kubebuilder:rbac:groups=router-hosts.fzymgc.house,resources=hostmappings,verbs=get;list;watch;create;update;patch;delete
@@ -197,8 +204,7 @@ func (r *HostMappingReconciler) reconcileUpdate(ctx context.Context, log *slog.L
 		// results a consistent server never returns on consecutive RPCs, so the
 		// chain terminates in one or two hops.
 		log.Warn("host entry not found on server; recreating", "staleHostId", hm.Status.HostID)
-		hm.Status.HostID = ""
-		return r.reconcileCreate(ctx, log, hm)
+		return r.recreateMissingHost(ctx, log, hm)
 	}
 	if getErr != nil || current == nil {
 		// Fail closed: without current state we cannot uphold idempotency or
@@ -242,8 +248,7 @@ func (r *HostMappingReconciler) reconcileUpdate(ctx context.Context, log *slog.L
 			// from the desired spec (see the GetHost branch above for why this
 			// recursion is bounded).
 			log.Warn("host entry vanished before update; recreating", "staleHostId", hm.Status.HostID)
-			hm.Status.HostID = ""
-			return r.reconcileCreate(ctx, log, hm)
+			return r.recreateMissingHost(ctx, log, hm)
 		}
 		log.Error("failed to update host entry", "error", err)
 		r.setStatus(hm, operatorv1alpha1.HostMappingPhaseError, err.Error(), hm.Status.HostID)
@@ -274,6 +279,28 @@ func (r *HostMappingReconciler) reconcileUpdate(ctx context.Context, log *slog.L
 
 	log.Info("host entry updated", "hostId", hm.Status.HostID)
 	return ctrl.Result{}, nil
+}
+
+// recreateMissingHost clears the stale Status.HostID and recreates the entry
+// from the desired spec after the server reported it missing (out-of-band
+// deletion). When the recreate converges (Phase=Synced) it emits a Normal
+// "Recreated" Event so an operator can see the controller reverted the deletion
+// — the resulting status (Message="Created") is otherwise indistinguishable in
+// kubectl from a first-time create. "Converged" also covers the case where
+// reconcileCreate hits AddHost->AlreadyExists and adopts a concurrently
+// recreated entry: the previously-missing host is restored either way, so the
+// Event still fires. It fires only on a successful recovery and only here, so a
+// genuine first-time create never emits it.
+func (r *HostMappingReconciler) recreateMissingHost(ctx context.Context, log *slog.Logger, hm *operatorv1alpha1.HostMapping) (ctrl.Result, error) {
+	staleID := hm.Status.HostID
+	hm.Status.HostID = ""
+
+	res, err := r.reconcileCreate(ctx, log, hm)
+	if err == nil && hm.Status.Phase == operatorv1alpha1.HostMappingPhaseSynced && hm.Status.HostID != "" && r.Recorder != nil {
+		r.Recorder.Eventf(hm, nil, corev1.EventTypeNormal, "Recreated", "Recreate",
+			"Recreated host entry %s after out-of-band deletion (previous id %q)", hm.Status.HostID, staleID)
+	}
+	return res, err
 }
 
 // reconcileDelete handles CR deletion by cleaning up the server-side host entry.

--- a/internal/operator/hostmapping_controller_test.go
+++ b/internal/operator/hostmapping_controller_test.go
@@ -12,6 +12,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/tools/events"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -1518,7 +1519,8 @@ func TestReconcile_Update_GetHostNotFound_RecreateAdoptsOnAlreadyExists(t *testi
 		},
 	}
 
-	r := &HostMappingReconciler{Client: k8sClient, Scheme: s, HostClient: mock, Log: slog.Default()}
+	rec := events.NewFakeRecorder(10)
+	r := &HostMappingReconciler{Client: k8sClient, Scheme: s, HostClient: mock, Log: slog.Default(), Recorder: rec}
 
 	result, err := r.Reconcile(context.Background(), ctrl.Request{
 		NamespacedName: types.NamespacedName{Name: "my-host", Namespace: "default"},
@@ -1530,4 +1532,149 @@ func TestReconcile_Update_GetHostNotFound_RecreateAdoptsOnAlreadyExists(t *testi
 	require.NoError(t, k8sClient.Get(context.Background(), types.NamespacedName{Name: "my-host", Namespace: "default"}, &updated))
 	assert.Equal(t, "adopted-id", updated.Status.HostID, "must adopt the existing entry")
 	assert.Equal(t, operatorv1alpha1.HostMappingPhaseSynced, updated.Status.Phase)
+
+	// The previously-missing host was restored (via adoption of a concurrently
+	// recreated entry), so the Recreated event still fires — pins the documented
+	// adopt-path behavior of recreateMissingHost.
+	events := drainEvents(rec)
+	require.Len(t, events, 1, "adopt-after-missing is a recovery; one Recreated event expected")
+	assert.Contains(t, events[0], "Recreated")
+}
+
+// drainEvents collects all events currently buffered on a FakeRecorder without
+// blocking once the channel is empty.
+func drainEvents(rec *events.FakeRecorder) []string {
+	var events []string
+	for {
+		select {
+		case e := <-rec.Events:
+			events = append(events, e)
+		default:
+			return events
+		}
+	}
+}
+
+// TestReconcile_Update_GetHostNotFound_EmitsRecreatedEvent verifies that when a
+// host deleted out-of-band is recreated (pre-update GetHost returns
+// ErrHostNotFound), the controller emits a Normal "Recreated" Kubernetes Event
+// so the corrective action is visible in kubectl, distinct from a first-time
+// create (follow-up #342).
+func TestReconcile_Update_GetHostNotFound_EmitsRecreatedEvent(t *testing.T) {
+	s := testScheme(t)
+	hm := newTestHostMapping("my-host", "default", "192.168.1.20", "updated.local")
+	hm.Finalizers = []string{hostCleanupFinalizer}
+	hm.Status.HostID = "stale-deleted-id"
+	hm.Status.HostVersion = "v1"
+	hm.Status.Phase = operatorv1alpha1.HostMappingPhaseSynced
+
+	k8sClient := fake.NewClientBuilder().
+		WithScheme(s).
+		WithObjects(hm).
+		WithStatusSubresource(hm).
+		Build()
+
+	mock := &mockHostClient{
+		getHostFn: func(_ context.Context, id string) (*HostEntry, error) {
+			if id == "stale-deleted-id" {
+				return nil, fmt.Errorf("getting host %s: %w", id, ErrHostNotFound)
+			}
+			return &HostEntry{ID: id, Version: "v1"}, nil
+		},
+		addHostFn: func(_ context.Context, _, _, _ string, _, _ []string) (string, error) {
+			return "recreated-id", nil
+		},
+	}
+
+	rec := events.NewFakeRecorder(10)
+	r := &HostMappingReconciler{Client: k8sClient, Scheme: s, HostClient: mock, Log: slog.Default(), Recorder: rec}
+
+	_, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "my-host", Namespace: "default"},
+	})
+	require.NoError(t, err)
+
+	events := drainEvents(rec)
+	require.Len(t, events, 1, "exactly one event expected")
+	assert.Contains(t, events[0], "Normal")
+	assert.Contains(t, events[0], "Recreated")
+}
+
+// TestReconcile_Update_UpdateHostNotFound_EmitsRecreatedEvent verifies the
+// Recreated event also fires on the second recreate path: the host vanishes
+// between the pre-update read and the write (UpdateHost returns ErrHostNotFound).
+func TestReconcile_Update_UpdateHostNotFound_EmitsRecreatedEvent(t *testing.T) {
+	s := testScheme(t)
+	hm := newTestHostMapping("my-host", "default", "192.168.1.20", "updated.local")
+	hm.Finalizers = []string{hostCleanupFinalizer}
+	hm.Status.HostID = "vanishing-id"
+	hm.Status.HostVersion = "v1"
+
+	k8sClient := fake.NewClientBuilder().
+		WithScheme(s).
+		WithObjects(hm).
+		WithStatusSubresource(hm).
+		Build()
+
+	mock := &mockHostClient{
+		getHostFn: func(_ context.Context, id string) (*HostEntry, error) {
+			if id == "vanishing-id" {
+				return &HostEntry{ID: id, IP: "192.168.1.20", Hostname: "updated.local", Version: "v1"}, nil
+			}
+			return &HostEntry{ID: id, Version: "v9"}, nil
+		},
+		updateHostFn: func(_ context.Context, id, _, _, _ string, _, _ []string, _ string) error {
+			return fmt.Errorf("updating host %s: %w", id, ErrHostNotFound)
+		},
+		addHostFn: func(_ context.Context, _, _, _ string, _, _ []string) (string, error) {
+			return "recreated-id", nil
+		},
+	}
+
+	rec := events.NewFakeRecorder(10)
+	r := &HostMappingReconciler{Client: k8sClient, Scheme: s, HostClient: mock, Log: slog.Default(), Recorder: rec}
+
+	_, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "my-host", Namespace: "default"},
+	})
+	require.NoError(t, err)
+
+	events := drainEvents(rec)
+	require.Len(t, events, 1, "exactly one event expected")
+	assert.Contains(t, events[0], "Recreated")
+}
+
+// TestReconcile_Create_NoRecreatedEvent verifies a genuine first-time create
+// does NOT emit a Recreated event — the event is reserved for corrective
+// recreation of an out-of-band-deleted host.
+func TestReconcile_Create_NoRecreatedEvent(t *testing.T) {
+	s := testScheme(t)
+	hm := newTestHostMapping("my-host", "default", "192.168.1.20", "new.local")
+	hm.Finalizers = []string{hostCleanupFinalizer}
+
+	k8sClient := fake.NewClientBuilder().
+		WithScheme(s).
+		WithObjects(hm).
+		WithStatusSubresource(hm).
+		Build()
+
+	mock := &mockHostClient{
+		addHostFn: func(_ context.Context, _, _, _ string, _, _ []string) (string, error) {
+			return "new-id", nil
+		},
+		getHostFn: func(_ context.Context, id string) (*HostEntry, error) {
+			return &HostEntry{ID: id, Version: "v1"}, nil
+		},
+	}
+
+	rec := events.NewFakeRecorder(10)
+	r := &HostMappingReconciler{Client: k8sClient, Scheme: s, HostClient: mock, Log: slog.Default(), Recorder: rec}
+
+	_, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "my-host", Namespace: "default"},
+	})
+	require.NoError(t, err)
+
+	events := drainEvents(rec)
+	assert.Empty(t, events, "first-time create must not emit a Recreated event")
 }

--- a/internal/operator/ingressroute_controller.go
+++ b/internal/operator/ingressroute_controller.go
@@ -3,6 +3,7 @@ package operator
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"regexp"
@@ -140,13 +141,32 @@ func (r *IngressRouteReconciler) reconcileUpsert(ctx context.Context, log *slog.
 	for _, hostname := range hosts {
 		if id, ok := existingIDs[hostname]; ok {
 			// Update existing entry.
-			if err := r.HostClient.UpdateHost(ctx, id, r.DefaultIP, hostname, comment, nil, tags, ""); err != nil {
+			switch err := r.HostClient.UpdateHost(ctx, id, r.DefaultIP, hostname, comment, nil, tags, ""); {
+			case err == nil:
+				newIDs[hostname] = id
+			case errors.Is(err, ErrHostNotFound):
+				// Host was deleted out-of-band. Mirror the HostMapping self-heal:
+				// recreate it in-pass rather than retaining the stale ID and
+				// looping forever on a missing entry. The IngressRoute spec is the
+				// source of truth (follow-up #342).
+				log.Warn("host entry not found on server; recreating", "hostname", hostname, "staleHostId", id)
+				if newID, addErr := r.HostClient.AddHost(ctx, r.DefaultIP, hostname, comment, nil, tags); addErr != nil {
+					// Retain the (now-dead) ID so the stale-cleanup loop below does
+					// not mistake an in-spec host for a removed one and issue a
+					// spurious DeleteHost. The host is still in the spec; the next
+					// pass re-detects NotFound and retries the recreate.
+					log.Error("failed to recreate host entry", "hostname", hostname, "error", addErr)
+					newIDs[hostname] = id
+					hadError = true
+				} else {
+					newIDs[hostname] = newID
+					log.Info("host entry recreated from IngressRoute", "hostname", hostname, "hostId", newID)
+				}
+			default:
 				log.Error("failed to update host entry", "hostname", hostname, "error", err)
 				newIDs[hostname] = id // retain existing ID so it's not lost
 				hadError = true
-				continue
 			}
-			newIDs[hostname] = id
 		} else {
 			// Create new entry.
 			id, err := r.HostClient.AddHost(ctx, r.DefaultIP, hostname, comment, nil, tags)

--- a/internal/operator/ingressroute_controller_test.go
+++ b/internal/operator/ingressroute_controller_test.go
@@ -530,6 +530,194 @@ func TestReconcile_IngressRoute_StaleDeleteFailure(t *testing.T) {
 	assert.Equal(t, "remove-id", ids["remove.example.com"])
 }
 
+// TestReconcile_IngressRoute_UpdateHostNotFound_Recreates verifies that when a
+// host tracked in the host-ids annotation was deleted out-of-band (UpdateHost
+// returns ErrHostNotFound), the controller recreates it in-pass via AddHost and
+// records the new ID, mirroring the HostMapping self-heal (follow-up #342).
+func TestReconcile_IngressRoute_UpdateHostNotFound_Recreates(t *testing.T) {
+	s := ingressRouteScheme(t)
+
+	existingIDs := map[string]string{"app.example.com": "stale-deleted-id"}
+	idsJSON, _ := json.Marshal(existingIDs)
+
+	obj := newIngressRoute("my-ir", "default", []map[string]interface{}{
+		{"match": "Host(`app.example.com`)"},
+	})
+	obj.SetFinalizers([]string{ingressRouteCleanupFinalizer})
+	obj.SetAnnotations(map[string]string{
+		hostIDsAnnotation: string(idsJSON),
+	})
+
+	k8sClient := fake.NewClientBuilder().
+		WithScheme(s).
+		WithObjects(obj).
+		Build()
+
+	addCalled := false
+	mock := &mockHostClient{
+		updateHostFn: func(_ context.Context, id, _, _, _ string, _, _ []string, _ string) error {
+			assert.Equal(t, "stale-deleted-id", id)
+			return fmt.Errorf("updating host %s: %w", id, ErrHostNotFound)
+		},
+		addHostFn: func(_ context.Context, ip, hostname, _ string, _, _ []string) (string, error) {
+			addCalled = true
+			assert.Equal(t, "10.0.0.1", ip)
+			assert.Equal(t, "app.example.com", hostname)
+			return "recreated-id", nil
+		},
+	}
+
+	r := &IngressRouteReconciler{
+		Client:      k8sClient,
+		HostClient:  mock,
+		Log:         slog.Default(),
+		DefaultIP:   "10.0.0.1",
+		DefaultTags: []string{"kubernetes"},
+	}
+
+	result, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "my-ir", Namespace: "default"},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, ctrl.Result{}, result, "in-pass recreate must succeed without an error requeue")
+	assert.True(t, addCalled, "must recreate the host via AddHost")
+
+	// Annotation must now point at the recreated ID, not the stale one.
+	var updated unstructured.Unstructured
+	updated.SetGroupVersionKind(ingressRouteGVK)
+	require.NoError(t, k8sClient.Get(context.Background(), types.NamespacedName{Name: "my-ir", Namespace: "default"}, &updated))
+	ids, err := getHostIDsAnnotation(slog.Default(), &updated)
+	require.NoError(t, err)
+	assert.Equal(t, "recreated-id", ids["app.example.com"])
+}
+
+// TestReconcile_IngressRoute_UpdateHostNotFound_RecreateFails_RetainsIDForRetry
+// verifies that when UpdateHost returns ErrHostNotFound and the in-pass AddHost
+// recreate also fails, the entry's ID is retained (so the next pass re-detects
+// NotFound and retries the recreate) and is NOT spuriously deleted by the
+// stale-cleanup pass — the host is still present in the spec.
+func TestReconcile_IngressRoute_UpdateHostNotFound_RecreateFails_RetainsIDForRetry(t *testing.T) {
+	s := ingressRouteScheme(t)
+
+	existingIDs := map[string]string{"app.example.com": "stale-deleted-id"}
+	idsJSON, _ := json.Marshal(existingIDs)
+
+	obj := newIngressRoute("my-ir", "default", []map[string]interface{}{
+		{"match": "Host(`app.example.com`)"},
+	})
+	obj.SetFinalizers([]string{ingressRouteCleanupFinalizer})
+	obj.SetAnnotations(map[string]string{
+		hostIDsAnnotation: string(idsJSON),
+	})
+
+	k8sClient := fake.NewClientBuilder().
+		WithScheme(s).
+		WithObjects(obj).
+		Build()
+
+	mock := &mockHostClient{
+		updateHostFn: func(_ context.Context, id, _, _, _ string, _, _ []string, _ string) error {
+			return fmt.Errorf("updating host %s: %w", id, ErrHostNotFound)
+		},
+		addHostFn: func(_ context.Context, _, _, _ string, _, _ []string) (string, error) {
+			return "", fmt.Errorf("server unavailable")
+		},
+		deleteHostFn: func(_ context.Context, id string) error {
+			t.Errorf("DeleteHost must not be called for an in-spec host (got id %q)", id)
+			return nil
+		},
+	}
+
+	r := &IngressRouteReconciler{
+		Client:      k8sClient,
+		HostClient:  mock,
+		Log:         slog.Default(),
+		DefaultIP:   "10.0.0.1",
+		DefaultTags: []string{"kubernetes"},
+	}
+
+	result, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "my-ir", Namespace: "default"},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, requeueDelayLong, result.RequeueAfter, "must requeue when recreate fails")
+
+	// The ID is retained so the next pass retries the recreate via UpdateHost.
+	var updated unstructured.Unstructured
+	updated.SetGroupVersionKind(ingressRouteGVK)
+	require.NoError(t, k8sClient.Get(context.Background(), types.NamespacedName{Name: "my-ir", Namespace: "default"}, &updated))
+	ids, err := getHostIDsAnnotation(slog.Default(), &updated)
+	require.NoError(t, err)
+	assert.Equal(t, "stale-deleted-id", ids["app.example.com"], "ID retained for retry, not deleted")
+}
+
+// TestReconcile_IngressRoute_MultiHost_RecreateAndUpdate verifies the mixed path
+// across multiple tracked hosts in one reconcile: one host returns ErrHostNotFound
+// and is recreated in-pass, a second updates normally, and neither is mistaken
+// for a stale entry by the cleanup loop (no DeleteHost). Both annotations end up
+// correct and the pass succeeds without a requeue.
+func TestReconcile_IngressRoute_MultiHost_RecreateAndUpdate(t *testing.T) {
+	s := ingressRouteScheme(t)
+
+	existingIDs := map[string]string{
+		"gone.example.com": "gone-id",
+		"live.example.com": "live-id",
+	}
+	idsJSON, _ := json.Marshal(existingIDs)
+
+	obj := newIngressRoute("my-ir", "default", []map[string]interface{}{
+		{"match": "Host(`gone.example.com`) || Host(`live.example.com`)"},
+	})
+	obj.SetFinalizers([]string{ingressRouteCleanupFinalizer})
+	obj.SetAnnotations(map[string]string{
+		hostIDsAnnotation: string(idsJSON),
+	})
+
+	k8sClient := fake.NewClientBuilder().
+		WithScheme(s).
+		WithObjects(obj).
+		Build()
+
+	mock := &mockHostClient{
+		updateHostFn: func(_ context.Context, id, _, _, _ string, _, _ []string, _ string) error {
+			if id == "gone-id" {
+				return fmt.Errorf("updating host %s: %w", id, ErrHostNotFound)
+			}
+			return nil // live-id updates normally
+		},
+		addHostFn: func(_ context.Context, _, hostname, _ string, _, _ []string) (string, error) {
+			assert.Equal(t, "gone.example.com", hostname, "only the NotFound host is recreated")
+			return "gone-recreated-id", nil
+		},
+		deleteHostFn: func(_ context.Context, id string) error {
+			t.Errorf("DeleteHost must not be called: both hosts are in spec (got id %q)", id)
+			return nil
+		},
+	}
+
+	r := &IngressRouteReconciler{
+		Client:      k8sClient,
+		HostClient:  mock,
+		Log:         slog.Default(),
+		DefaultIP:   "10.0.0.1",
+		DefaultTags: []string{"kubernetes"},
+	}
+
+	result, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "my-ir", Namespace: "default"},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, ctrl.Result{}, result, "all hosts converged; no requeue")
+
+	var updated unstructured.Unstructured
+	updated.SetGroupVersionKind(ingressRouteGVK)
+	require.NoError(t, k8sClient.Get(context.Background(), types.NamespacedName{Name: "my-ir", Namespace: "default"}, &updated))
+	ids, err := getHostIDsAnnotation(slog.Default(), &updated)
+	require.NoError(t, err)
+	assert.Equal(t, "gone-recreated-id", ids["gone.example.com"], "recreated host gets the new ID")
+	assert.Equal(t, "live-id", ids["live.example.com"], "normally-updated host keeps its ID")
+}
+
 func TestReconcile_IngressRoute_NoHosts(t *testing.T) {
 	s := ingressRouteScheme(t)
 


### PR DESCRIPTION
## Summary

Two non-blocking follow-ups deferred from PR #342 (bead `router-hosts-q4y`):

- **IngressRoute recreate symmetry** — `IngressRouteReconciler.reconcileUpsert`
  now mirrors the HostMapping self-heal. On `UpdateHost` → `ErrHostNotFound`
  (host deleted out-of-band) it recreates the entry **in-pass** via `AddHost`
  instead of retaining the stale ID and requeuing forever. On a failed recreate
  it **retains** the dead ID (rather than dropping it) so the stale-cleanup loop
  doesn't mistake an in-spec host for a removed one and issue a spurious
  `DeleteHost`; the next pass re-detects `NotFound` and retries.
- **Recreate observability** — `HostMappingReconciler` gains a `Recorder` and
  routes both recreate branches through `recreateMissingHost`, which emits a
  `Normal "Recreated"` Kubernetes Event on a converged recreate. Previously the
  recovery reported `Phase=Synced Message="Created"`, indistinguishable in
  `kubectl` from a first-time create. Wired via `mgr.GetEventRecorder` in
  `cmd/operator/main.go` — the first controller in the repo to record Events,
  establishing the pattern.

### Notable decisions
- Used the **non-deprecated** `events.EventRecorder` API
  (`k8s.io/client-go/tools/events` + `mgr.GetEventRecorder`), **not** the
  bead-suggested `record.EventRecorder` / `GetEventRecorderFor`, which
  staticcheck (SA1019) flags as deprecated and fails `task lint`.
- Declined the optional distinct status `Message`: it would be overwritten by
  `"Already in sync"` on the next resync — the Event is the durable record.
- `Recorder` is nil-guarded (best-effort telemetry, never control flow), so
  existing reconciler tests need no recorder.

## Test Plan

- [x] `task lint` — 0 issues
- [x] `task test` (full suite, `-race`) — pass
- [x] `task test:coverage:ci` — 84.7% overall (operator pkg 87.4%), ≥80% gate
- [x] New tests: IngressRoute in-pass recreate + retain-on-failure (no spurious
      delete); HostMapping `Recreated` event on both recreate branches; no event
      on first-time create
- [x] No generated-manifest drift (`task manifests`)

Refs #342

🤖 Generated with [Claude Code](https://claude.com/claude-code)
